### PR TITLE
Make DELETE of nonexistent resource succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client now logs Pulp load every few minutes when awaiting tasks
 - Client now logs warnings when Pulp operations are being retried
 - Cancelling a future now attempts to cancel underlying Pulp task(s)
+- Deleting a resource which is already nonexistent now succeeds
 
 ## [0.1.1] - 2019-06-13
 

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -90,12 +90,8 @@ class FakeClient(object):
                     break
 
             if not found:
-                # TODO: real client should perhaps return successful here
-                # since postcondition is already satisfied. If it's modified to do
-                # so, this will also need updating.
-                return f_return_error(
-                    PulpException("Repository not found: %s" % repo_id)
-                )
+                # Deleting something which already doesn't exist is fine
+                return f_return([])
 
             self._repositories.pop(idx)  # pylint: disable=undefined-loop-variable
             return f_return(

--- a/tests/fake/test_fake_delete.py
+++ b/tests/fake/test_fake_delete.py
@@ -29,7 +29,7 @@ def test_can_delete():
     assert controller.repositories == [Repository(id="repo2")]
 
 
-def test_delete_missing_repo_fails():
+def test_delete_missing_repo_succeeds():
     controller = FakeController()
 
     controller.insert_repository(Repository(id="repo"))
@@ -42,10 +42,9 @@ def test_delete_missing_repo_fails():
     repo_copy1 = client.get_repository("repo").result()
     repo_copy2 = client.get_repository("repo").result()
 
-    # First delete succeeds
+    # First delete succeeds, with some tasks
     assert repo_copy1.delete().result()
 
-    # Second delete should give an error since repo no longer exists
-    exception = repo_copy2.delete().exception()
-    assert isinstance(exception, PulpException)
-    assert "Repository not found: repo" in str(exception)
+    # Second delete also succeeds, but there are no tasks since repo
+    # already doesn't exist
+    assert repo_copy2.delete().result() == []

--- a/tests/repository/test_delete.py
+++ b/tests/repository/test_delete.py
@@ -61,3 +61,40 @@ def test_delete_detaches(fast_poller, requests_mocker, client):
     # Second attempt to delete doesn't make sense
     with pytest.raises(DetachedException):
         repo.delete()
+
+
+def test_delete_absent(fast_poller, requests_mocker, client):
+    """delete of an object which already doesn't exist is successful"""
+
+    # Two handles to same repo
+    repo1 = Repository(id="some-repo")
+    repo1.__dict__["_client"] = client
+
+    repo2 = Repository(id="some-repo")
+    repo2.__dict__["_client"] = client
+
+    requests_mocker.delete(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/",
+        [
+            # first attempt to delete
+            dict(json={"spawned_tasks": [{"task_id": "task1"}]}),
+            # second attempt fails as 404 because it already was deleted
+            dict(
+                status_code=404,
+                json={"http_status": 404, "http_request_method": "DELETE"},
+            ),
+        ],
+    )
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        json=[{"task_id": "task1", "state": "finished"}],
+    )
+
+    # Delete via first handle succeeds with the spawned task
+    assert sorted(repo1.delete().result()) == [
+        Task(id="task1", succeeded=True, completed=True)
+    ]
+
+    # Delete via second handle also succeeds, but with no tasks
+    assert sorted(repo2.delete().result()) == []


### PR DESCRIPTION
If we ask to DELETE something and it already doesn't exist, that
should be considered successful since the postcondition of our
request is met.

This is important because it makes DELETE operations idempotent;
without this, a delete interrupted by a network glitch may not
be able to complete by retrying.