### PR TITLE
Drop jsonschema requirement down to 2.3.0

### DIFF
--- a/pubtools/pulplib/_impl/model/distributor.py
+++ b/pubtools/pulplib/_impl/model/distributor.py
@@ -8,7 +8,7 @@ from .. import compat_attr as attr
 class Distributor(PulpObject):
     """Represents a Pulp distributor."""
 
-    _SCHEMA = load_schema("repository", "#/definitions/distributor")
+    _SCHEMA = load_schema("repository", "distributor")
 
     id = pulp_attrib(type=str, pulp_field="id")
     """ID of this distributor (str).

--- a/pubtools/pulplib/_impl/schema/__init__.py
+++ b/pubtools/pulplib/_impl/schema/__init__.py
@@ -8,21 +8,17 @@ import jsonschema
 LOG = logging.getLogger("pubtools.pulplib")
 
 
-def load_schema(basename, ref="#"):
+def load_schema(basename, definition=None):
     """Load a JSON schema file from YAML.
 
-    If ref is given, a subschema can be referenced.
-    For example, ref="#/definitions/foobar" will load the subschema
-    "foobar" from the definitions section
+    If definition is given, a subschema can be referenced.
     """
 
     filename = os.path.join(os.path.dirname(__file__), "%s.yaml" % basename)
     with open(filename) as file:
         schema = yaml.safe_load(file)
 
-    resolver = jsonschema.RefResolver.from_schema(schema)
-    (resolved_ref, resolved_schema) = resolver.resolve(ref)
+    if definition:
+        schema = schema["definitions"][definition]
 
-    LOG.debug("Resolved %s to %s", ref, resolved_ref)
-
-    return resolved_schema
+    return schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ requests
 more-executors>=2.1.0
 six
 PyYAML
-# For RefResolver.resolve
-jsonschema>=2.5.0
+jsonschema
 attrs
 six

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps=
 	attrs==17.4.0
 	pytest==3.2.5
 	pytest-capturelog
-	jsonschema==2.5.0
+	jsonschema==2.3.0
 	requests-mock
 	mock
 


### PR DESCRIPTION
Remove usage of RefResolver.resolve.  It probably wasn't a good idea
anyway since that's not documented as public API.