### PR TITLE
tests: fix a couple of unstable tests, particularly on Python 2

### DIFF
--- a/tests/client/test_search_stops.py
+++ b/tests/client/test_search_stops.py
@@ -1,10 +1,11 @@
 import time
-from pubtools.pulplib import Repository
+from pubtools.pulplib import Client
 
 
-def test_search_stops_paginate(client, requests_mocker):
+def test_search_stops_paginate(requests_mocker):
     """Paginated search will stop issuing requests if pages are no longer referenced."""
 
+    client = Client("https://pulp.example.com/")
     client._PAGE_SIZE = 10
 
     responses = []
@@ -17,6 +18,21 @@ def test_search_stops_paginate(client, requests_mocker):
             current_response = []
 
     responses.append({"json": current_response})
+
+    # Inject a failing response for stable behavior from test:
+    #
+    # The expected behavior is that, after the first two requests,
+    # pagination is cancelled since we no longer hold onto a page.
+    # But that cancellation is racing with the scheduling of the
+    # request, and there is generally no way to ensure our cancel
+    # happens before the request thread starts the request, so we
+    # can't be sure about how many requests we'd do.
+    #
+    # However, if we insert a failure after the first two pages,
+    # then the client will need to retry a request (with some delay).
+    # It should always be possible to cancel the request during that
+    # retry delay, making the test stable.
+    responses.insert(2, {"status_code": 500})
 
     requests_mocker.post(
         "https://pulp.example.com/pulp/api/v2/repositories/search/", responses

--- a/tests/client/test_search_stops.py
+++ b/tests/client/test_search_stops.py
@@ -7,12 +7,10 @@ def test_search_stops_paginate(client, requests_mocker):
 
     client._PAGE_SIZE = 10
 
-    expected_repos = []
     responses = []
     current_response = []
     for i in range(0, 997):
         repo_id = "repo-%s" % i
-        expected_repos.append(Repository(id=repo_id))
         current_response.append({"id": repo_id})
         if len(current_response) == client._PAGE_SIZE:
             responses.append({"json": current_response})

--- a/tests/client/test_search_stops.py
+++ b/tests/client/test_search_stops.py
@@ -2,7 +2,7 @@ import time
 from pubtools.pulplib import Repository
 
 
-def test_search_can_paginate(client, requests_mocker):
+def test_search_stops_paginate(client, requests_mocker):
     """Paginated search will stop issuing requests if pages are no longer referenced."""
 
     client._PAGE_SIZE = 10

--- a/tests/repository/test_publish_cancel.py
+++ b/tests/repository/test_publish_cancel.py
@@ -44,6 +44,10 @@ def test_publish_cancel(fast_poller, requests_mocker, client, caplog):
     assert publish_f.cancel()
 
     # It should have cancelled the underlying Pulp task
-    req = requests_mocker.last_request
-    assert req.url == "https://pulp.example.com/pulp/api/v2/tasks/task1/"
-    assert req.method == "DELETE"
+    task_req = [
+        r
+        for r in requests_mocker.request_history
+        if r.url == "https://pulp.example.com/pulp/api/v2/tasks/task1/"
+    ]
+    assert len(task_req) == 1
+    assert task_req[0].method == "DELETE"


### PR DESCRIPTION
These were unstable due to reliance on scheduling of threads.

Fixes #21 