### PR TITLE
Bump more-executors minimum version for fix of flaky tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-more-executors>=2.1.0
+more-executors>=2.1.2
 six
 PyYAML
 jsonschema


### PR DESCRIPTION
Despite prior fixes, test_search_stops_paginate was still a little
flaky. This was due to a race condition in RetryExecutor fixed
in more-executors 2.1.2. Bump the minimum version of the dep to
ensure we always have the bugfix.

Fixes #21