### PR TITLE
Support searching by regex, with minor refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- Extended search functionality to support matching fields by regular expression,
+  using new `Matcher` class
+
+### Deprecated
+- `Criteria.exists` is now deprecated in favor of `Matcher.exists()`
+- `Criteria.with_field_in` is now deprecated in favor of `Matcher.in_()`
 
 ## [1.0.0] - 2019-06-26
 

--- a/docs/api/searching.rst
+++ b/docs/api/searching.rst
@@ -1,9 +1,11 @@
 Searching
 =========
 
-.. autoclass:: pubtools.pulplib.Page
-   :members:
-
 .. autoclass:: pubtools.pulplib.Criteria
    :members:
 
+.. autoclass:: pubtools.pulplib.Matcher
+   :members:
+
+.. autoclass:: pubtools.pulplib.Page
+   :members:

--- a/examples/garbage-collect
+++ b/examples/garbage-collect
@@ -5,14 +5,14 @@ from concurrent.futures import wait
 from datetime import datetime, timedelta
 from argparse import ArgumentParser
 
-from pubtools.pulplib import Client, Criteria
+from pubtools.pulplib import Client, Criteria, Matcher
 
 log = logging.getLogger("garbage-collect")
 
 
 def garbage_collect(client, gc_threshold=7):
     crit = Criteria.and_(
-        Criteria.with_field("notes.created", Criteria.exists),
+        Criteria.with_field("notes.created", Matcher.exists()),
         Criteria.with_field("notes.pub_temp_repo", True),
     )
 

--- a/pubtools/pulplib/__init__.py
+++ b/pubtools/pulplib/__init__.py
@@ -1,5 +1,5 @@
 from ._impl.client import Client, PulpException, TaskFailedException
-from ._impl.criteria import Criteria
+from ._impl.criteria import Criteria, Matcher
 from ._impl.page import Page
 from ._impl.model import (
     PulpObject,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="1.0.0",
+    version="1.1.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -1,6 +1,8 @@
-from pubtools.pulplib import Criteria
+import pytest
 
-from pubtools.pulplib._impl.client.search import filters_for_criteria
+from pubtools.pulplib import Criteria, Matcher
+
+from pubtools.pulplib._impl.client.search import filters_for_criteria, field_match
 
 
 def test_null_criteria():
@@ -46,3 +48,24 @@ def test_field_or_criteria():
     assert filters_for_criteria(Criteria.or_(c1, c2)) == {
         "$or": [{"f1": {"$eq": "v1"}}, {"f2": {"$eq": "v2"}}]
     }
+
+
+def test_field_regex_criteria():
+    """with_field with regex is translated to a mongo fragment as expected."""
+
+    assert filters_for_criteria(
+        Criteria.with_field("some.field", Matcher.regex("abc"))
+    ) == {"some.field": {"$regex": "abc"}}
+
+
+def test_non_matcher():
+    """field_match raises if invoked with something other than a matcher.
+
+    This is not possible to reach by public API alone; it'd be an internal bug
+    if this exception is ever raised.
+    """
+
+    with pytest.raises(TypeError) as exc_info:
+        field_match("oops not a matcher")
+
+    assert "Not a matcher" in str(exc_info)

--- a/tests/criteria/test_matcher.py
+++ b/tests/criteria/test_matcher.py
@@ -1,0 +1,12 @@
+import re
+
+import pytest
+
+from pubtools.pulplib import Matcher
+
+
+def test_matcher_regex_invalid():
+    """Matcher.regex raises if passed value is not a valid regular expression."""
+
+    with pytest.raises(re.error):
+        Matcher.regex("foo [bar")


### PR DESCRIPTION
We have a use-case for searching repositories by regular expression,
so let's implement that.

Includes some backwards-compatible refactoring of the Criteria API.
Criteria and Matcher are now two separate concepts. This avoids
having to implement e.g. "with_field", "with_field_regex" and so
on methods for any type of matching we might want to do.