### PR TITLE
Fix test failures with pytest 5

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -164,4 +164,4 @@ def test_get_missing(client, requests_mocker):
         repo_f.result()
 
     # It should explain the problem
-    assert "repo1 was not found" in str(error)
+    assert "repo1 was not found" in str(error.value)

--- a/tests/client/test_poller.py
+++ b/tests/client/test_poller.py
@@ -182,4 +182,4 @@ def test_retries_exhausted(requests_mocker):
         poller(descriptors)
 
     # It should pass through whatever was the underlying error
-    assert "400 Client Error" in str(exc_info)
+    assert "400 Client Error" in str(exc_info.value)

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -68,4 +68,4 @@ def test_non_matcher():
     with pytest.raises(TypeError) as exc_info:
         field_match("oops not a matcher")
 
-    assert "Not a matcher" in str(exc_info)
+    assert "Not a matcher" in str(exc_info.value)

--- a/tests/criteria/test_criteria.py
+++ b/tests/criteria/test_criteria.py
@@ -12,4 +12,4 @@ def test_field_in_str_invalid():
     """
     with pytest.raises(ValueError) as exc_info:
         Criteria.with_field_in("x", "someval")
-    assert "Must be an iterable: 'someval'" in str(exc_info)
+    assert "Must be an iterable: 'someval'" in str(exc_info.value)

--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -33,7 +33,7 @@ def test_get_missing_raises():
     with pytest.raises(PulpException) as raised:
         repo_f.result()
 
-    assert "some-repo not found" in str(raised)
+    assert "some-repo not found" in str(raised.value)
 
 
 def test_get_wrong_type_raises():

--- a/tests/repository/test_publish.py
+++ b/tests/repository/test_publish.py
@@ -171,7 +171,7 @@ def test_publish_fail(fast_poller, requests_mocker, client):
 
     # The exception should have a reference to the task which failed
     assert error.value.task.id == "task1"
-    assert "Task task1 failed" in str(error)
+    assert "Task task1 failed" in str(error.value)
 
 
 def test_publish_broken_response(fast_poller, requests_mocker, client):

--- a/tests/util/test_lookup.py
+++ b/tests/util/test_lookup.py
@@ -17,7 +17,7 @@ def test_lookup_nested_absent_raise():
     with pytest.raises(KeyError) as error:
         lookup(data, "a.b.d")
 
-    assert "a.b.d" in str(error)
+    assert "a.b.d" in str(error.value)
 
 
 def test_lookup_nested_absent_default():


### PR DESCRIPTION
str() behavior on pytest ExceptionInfo objects was changed in
pytest 5.0.0: https://github.com/pytest-dev/pytest/issues/5412

This caused various tests to fail, as it was assumed that str()
on those objects would include exception messages. Update the
tests to check the exceptions instead, rather than the
ExceptionInfo wrappers.