### PR TITLE
Introduce the Repository.is_temporary attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- Introduced ``Repository.is_temporary`` attribute
 
 ## [1.2.1] - 2019-08-12
 

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -116,6 +116,19 @@ class Repository(PulpObject):
     """True if this is a sigstore repository, used for container image manifest
     signatures."""
 
+    is_temporary = pulp_attrib(
+        default=False, type=bool, pulp_field="notes.pub_temp_repo"
+    )
+    """True if this is a temporary repository.
+
+    A temporary repository is a repository created by release-engineering tools
+    for temporary use during certain workflows.  Such repos are not expected to
+    be published externally and generally should have a lifetime of a few days
+    or less.
+
+    .. versionadded:: 1.3.0
+    """
+
     signing_keys = pulp_attrib(
         default=attr.Factory(list),
         type=list,

--- a/pubtools/pulplib/_impl/schema/repository.yaml
+++ b/pubtools/pulplib/_impl/schema/repository.yaml
@@ -75,6 +75,11 @@ properties:
       signatures:
         type: string
 
+      # True if this is considered a temporary repository, created for
+      # use during certain workflows and deleted later
+      pub_temp_repo:
+        type: boolean
+
   # List of repository distributors.
   # Note that order matters in this list.
   distributors:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="1.2.1",
+    version="1.3.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/repository/test_repository_from_data.py
+++ b/tests/repository/test_repository_from_data.py
@@ -34,6 +34,18 @@ def test_bad_created():
         Repository.from_data({"id": "some-repo", "notes": {"created": "whoops"}})
 
 
+def test_is_temporary():
+    """from_data is_temporary is True if expected note is present"""
+    repo = Repository.from_data({"id": "some-repo", "notes": {"pub_temp_repo": True}})
+    assert repo.is_temporary
+
+
+def test_is_not_temporary():
+    """from_data is_temporary is False by default"""
+    repo = Repository.from_data({"id": "some-repo"})
+    assert not repo.is_temporary
+
+
 def test_attr_created():
     """from_data sets created attribute appropriately"""
     repo = Repository.from_data(


### PR DESCRIPTION
This attribute tells us whether a repository should be considered
"temporary" (i.e. it's created to support execution of some
workflow and should be deleted once that's complete).