### PR TITLE
CI: add API compatibility check using pidiff tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   - python: "3.6"
     env: TOX_ENV=static
   - python: "3.6"
+    env: TOX_ENV=pidiff
+  - python: "3.6"
     env: TOX_ENV=cov-travis DEPLOY=1
   - python: "3.6"
     env: TOX_ENV=docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,static,docs
+envlist = py27,py36,static,pidiff,docs
 
 [testenv]
 deps=-rtest-requirements.txt
@@ -22,6 +22,11 @@ deps=
 commands=
 	black --check .
 	sh -c 'pylint pubtools; test $(( $? & (1|2|4|32) )) = 0'
+
+[testenv:pidiff]
+deps=pidiff
+skip_install=true
+commands=pidiff pubtools-pulplib .
 
 [testenv:cov]
 deps=


### PR DESCRIPTION
This tool checks the public API for any changes compared to the
latest version on PyPI, and will complain if semver-incompatible
changes were detected.

The main goal is to protect against accidental
backwards-incompatible API changes.