### PR TITLE
match_field_exists in fake.match.py to return false for fields with None

### DIFF
--- a/pubtools/pulplib/_impl/fake/match.py
+++ b/pubtools/pulplib/_impl/fake/match.py
@@ -112,7 +112,7 @@ def match_field_regex(matcher, field, obj):
 @visit(ExistsMatcher)
 def match_field_exists(_matcher, field, obj):
     value = get_field(field, obj)
-    return value is not ABSENT
+    return value not in [ABSENT, None]
 
 
 @visit(InMatcher)

--- a/tests/fake/test_fake_search.py
+++ b/tests/fake/test_fake_search.py
@@ -112,6 +112,28 @@ def test_search_created_exists():
     assert sorted(found) == [repo2, repo3]
 
 
+def test_search_with_model_field():
+    """search repos using model field 'created' in criteria.
+    returns only those repos which has the field and value is
+    not None
+    """
+    controller = FakeController()
+
+    repo1 = Repository(id="repo1")
+    repo2 = Repository(id="repo2", created=datetime.datetime.utcnow())
+    repo3 = Repository(id="repo3", created=None)
+
+    controller.insert_repository(repo1)
+    controller.insert_repository(repo2)
+    controller.insert_repository(repo3)
+
+    client = controller.client
+    crit = Criteria.with_field("created", Matcher.exists())
+    found = client.search_repository(crit).result().data
+
+    assert sorted(found) == [repo2]
+
+
 def test_search_and():
     controller = FakeController()
 


### PR DESCRIPTION
match_field_exists returns true if an attribute of the
model object is none and that attribute is checked if
it exists. This change modifies to return true only
if the field is present and has some value.

fix #39 