### PR TITLE
Introduce Client.get_content_type_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-n/a
+### Added
+- Introduced ``Client.get_content_type_ids`` method to retrieve supported content types.
 
 ## [1.3.0] - 2019-08-15
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -181,6 +181,29 @@ class Client(object):
             response_f, lambda data: self._handle_page(Repository, search, data)
         )
 
+    def get_content_type_ids(self):
+        """Get the content types supported by this Pulp server.
+
+        Returns:
+            Future[list[str]]
+                A future holding the IDs of supported content types.
+
+                The returned values will depend on the plugins installed
+                on the connected Pulp server.
+
+                "modulemd", "rpm", "srpm" and "erratum" are some examples
+                of common return values.
+
+        .. versionadded:: 1.4.0
+        """
+        url = os.path.join(self._url, "pulp/api/v2/plugins/types/")
+
+        out = self._request_executor.submit(self._do_request, method="GET", url=url)
+
+        # The pulp API returns an object per supported type.
+        # We only support returning the ID at this time.
+        return f_map(out, lambda types: sorted([t["id"] for t in types]))
+
     def _do_upload_file(self, upload_id, file_obj, name):
         def do_next_upload(checksum, size):
             data = file_obj.read(self._CHUNK_SIZE)

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -27,11 +27,28 @@ class FakeClient(object):
     # written against pubtools.pulplib.Client should be able to work with
     # an instance of this class swapped in.
     _PAGE_SIZE = 3
+    _DEFAULT_TYPE_IDS = [
+        "distribution",
+        "drpm",
+        "erratum",
+        "iso",
+        "modulemd_defaults",
+        "modulemd",
+        "package_category",
+        "package_environment",
+        "package_group",
+        "package_langpacks",
+        "repository",
+        "rpm",
+        "srpm",
+        "yum_repo_metadata_file",
+    ]
 
     def __init__(self):
         self._repositories = []
         self._publish_history = []
         self._upload_history = []
+        self._type_ids = self._DEFAULT_TYPE_IDS[:]
         self._lock = threading.RLock()
         self._uuidgen = random.Random()
         self._uuidgen.seed(0)
@@ -89,6 +106,9 @@ class FakeClient(object):
             )
 
         return f_return(data[0])
+
+    def get_content_type_ids(self):
+        return f_return(self._type_ids)
 
     def _do_upload_file(self, upload_id, file_obj, name):
         # pylint: disable=unused-argument

--- a/pubtools/pulplib/_impl/fake/controller.py
+++ b/pubtools/pulplib/_impl/fake/controller.py
@@ -66,6 +66,25 @@ class FakeController(object):
         self.client._repositories.append(repository)
 
     @property
+    def content_type_ids(self):
+        """The list of content type IDs the fake client will claim to support.
+
+        .. versionadded:: 1.4.0
+        """
+        return self.client._type_ids[:]
+
+    def set_content_type_ids(self, type_ids):
+        """Set the list of content type IDs the fake client will claim to support.
+
+        Args:
+            type_ids (list[str])
+                A list of content type IDs (e.g. "rpm", "erratum", ...)
+
+        .. versionadded:: 1.4.0
+        """
+        self.client._type_ids = type_ids[:]
+
+    @property
     def publish_history(self):
         """A list of repository publishes triggered via this client.
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="1.3.0",
+    version="1.4.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_content_type_ids.py
+++ b/tests/client/test_content_type_ids.py
@@ -1,0 +1,11 @@
+def test_can_get_content_type_ids(client, requests_mocker):
+    """get_content_type_ids obtains type info from Pulp API as expected."""
+    requests_mocker.get(
+        "https://pulp.example.com/pulp/api/v2/plugins/types/",
+        json=[{"id": "type2"}, {"id": "type1"}],
+    )
+
+    type_ids = client.get_content_type_ids().result()
+
+    # It should have returned the supported type IDs
+    assert type_ids == ["type1", "type2"]

--- a/tests/fake/test_fake_content_type_ids.py
+++ b/tests/fake/test_fake_content_type_ids.py
@@ -1,0 +1,28 @@
+from pubtools.pulplib import FakeController
+
+
+def test_default_content_type_ids():
+    """Fake client by default supports various common types."""
+    controller = FakeController()
+    client = controller.client
+
+    type_ids = client.get_content_type_ids().result()
+
+    # Type IDs should include this common content types.
+    assert "rpm" in type_ids
+    assert "erratum" in type_ids
+    assert "modulemd" in type_ids
+
+    # Type IDs reported by client should match controller.
+    assert sorted(type_ids) == sorted(controller.content_type_ids)
+
+
+def test_set_content_type_ids():
+    """Fake controller can be used to set content type IDs."""
+    controller = FakeController()
+    client = controller.client
+
+    controller.set_content_type_ids(["a", "b", "c"])
+
+    type_ids = client.get_content_type_ids().result()
+    assert sorted(type_ids) == ["a", "b", "c"]


### PR DESCRIPTION
Simple API to obtain the content types supported by the Pulp server.

The use-case for this API is the clear-repo command. This command
is able to accept specific content types to operate on. We'll need
to validate content types passed by the user, which means we need
to know which content types are supported by the server.