### PR TITLE
CI: add reverse-dependency testing for pubtools-pulp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     env: TOX_ENV=cov-travis DEPLOY=1
   - python: "3.6"
     env: TOX_ENV=docs
+  - python: "3.6"
+    env: TOX_ENV=revdep-pubtools-pulp
 script: tox -e $TOX_ENV
 after_success:
 - test $TOX_ENV = docs && scripts/push-docs

--- a/scripts/revdep-test
+++ b/scripts/revdep-test
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Reverse dependency tester.
+#
+# Usage: revdep-test <git-url>
+#
+# This script is intended to be run within a virtualenv with latest
+# version of this project installed. It'll run autotests from
+# some *other* project which depends on this one.
+#
+# The project must satisfy requirements:
+# - is itself pip-installable
+# - must support py.test for test running
+# - if tests need extra reqs, they must be in test-requirements.txt
+#
+URL="$1"
+
+CLONE_DIR=$(mktemp -d -t --suffix=revdep)
+
+clean(){
+  rm -rf $CLONE_DIR
+}
+trap clean EXIT
+
+set -xe
+
+git clone "$URL" "$CLONE_DIR"
+cd "$CLONE_DIR"
+
+pip install --editable .
+if test -e test-requirements.txt; then
+  pip install -rtest-requirements.txt
+fi
+
+py.test -v

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,static,pidiff,docs
+envlist = py27,py36,static,pidiff,docs,revdep-pubtools-pulp
 
 [testenv]
 deps=-rtest-requirements.txt
@@ -46,6 +46,11 @@ usedevelop=true
 commands=
 	pytest --cov=pubtools {posargs}
 	coveralls
+
+[testenv:revdep-pubtools-pulp]
+usedevelop=true
+whitelist_externals=sh
+commands=sh -c 'scripts/revdep-test https://github.com/release-engineering/pubtools-pulp.git'
 
 [testenv:docs]
 deps=


### PR DESCRIPTION
Don't allow incoming changes to pubtools-pulplib unless
pubtools-pulp tests also pass with the changes. This gives added
protection against regressions and backwards-incompatible changes.