### PR TITLE
Deprecate Page.as_iter in preference of __iter__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- ``Page`` objects may now be directly used as iterables
+
+### Deprecated
+- ``Page.as_iter`` is now deprecated.
 
 ## [1.5.0] - 2019-09-03
 

--- a/examples/dump-repos
+++ b/examples/dump-repos
@@ -37,7 +37,7 @@ def dump_repos(client, crit_strings):
     log.info("Starting Pulp search with %s", repr(criteria))
 
     count = 0
-    repos = client.search_repository(criteria).result().as_iter()
+    repos = client.search_repository(criteria).result()
     for repo in repos:
         count += 1
         log.info("Repo: %s", repr(repo))

--- a/examples/garbage-collect
+++ b/examples/garbage-collect
@@ -17,7 +17,7 @@ def garbage_collect(client, gc_threshold=7):
     )
 
     repos = client.search_repository(crit).result()
-    for repo in repos.as_iter():
+    for repo in repos:
         created = repo.created
         if not created:
             log.warning("Can't check repo %s - no creation time available", repo.id)

--- a/examples/publish
+++ b/examples/publish
@@ -14,7 +14,7 @@ def publish(client, repo_id):
     crit = Criteria.with_id(repo_id)
 
     repos = client.search_repository(crit).result()
-    publishes = [repo.publish() for repo in repos.as_iter()]
+    publishes = [repo.publish() for repo in repos]
 
     # Blocks at result() calls here.
     publish_tasks = []

--- a/examples/set-maintenance
+++ b/examples/set-maintenance
@@ -17,7 +17,7 @@ def set_maintenance(client, regex):
     # search repo
     repos = self.search_repository(crit).result()
 
-    repo_ids = [repo.id for repo in repos.as_iter()]
+    repo_ids = [repo.id for repo in repos]
     report = report.add(repo_ids)
     # get the repo ids and feed to report
 

--- a/pubtools/pulplib/_impl/page.py
+++ b/pubtools/pulplib/_impl/page.py
@@ -92,6 +92,7 @@ class Page(object):
             self.__dict__["_cancel_ref"] = weakref.ref(self, do_cancel)
 
     def as_iter(self):
+        # TODO: remove me. Originally deprecated 2019-09.
         warnings.warn(
             "as_iter is deprecated, use page as iterable instead", DeprecationWarning
         )

--- a/pubtools/pulplib/_impl/page.py
+++ b/pubtools/pulplib/_impl/page.py
@@ -1,5 +1,6 @@
 import logging
 import weakref
+import warnings
 
 from . import compat_attr as attr
 
@@ -13,6 +14,10 @@ class Page(object):
     All Pulp searches issued by this library are paginated.
     Instances of this class may be used to iterate through the returned
     pages, in both blocking and non-blocking coding styles.
+
+    Page objects are iterables. Iterating over a page will iterate
+    over all data within that page, *and all subsequent pages*,
+    blocking on more data from Pulp as needed.
 
     Examples:
 
@@ -41,15 +46,15 @@ class Page(object):
 
         **Blocking iteration**
 
-        This example uses :meth:`as_iter` to loop over all search results.
-        At certain points during the iteration, blocking may occur to
-        await more pages from Pulp.
+        This example uses the page as an iterable to loop over all search
+        results. At certain points during the iteration, blocking may
+        occur to await more pages from Pulp.
 
         .. code-block:: python
 
             page = client.search_repository(...).result()
             # processes all data, but may block at page boundaries
-            for repo in page.as_iter():
+            for repo in page:
                 do_something(repo)
 
     """
@@ -87,12 +92,13 @@ class Page(object):
             self.__dict__["_cancel_ref"] = weakref.ref(self, do_cancel)
 
     def as_iter(self):
-        """Returns an iterator which individually yields each object in this
-        page, and all subsequent pages.
+        warnings.warn(
+            "as_iter is deprecated, use page as iterable instead", DeprecationWarning
+        )
 
-        The iterator will block as needed if the current Pulp search has not
-        yet completed.
-        """
+        return self.__iter__()
+
+    def __iter__(self):
         page = self
         while True:
             for elem in page.data:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="1.5.0",
+    version="1.6.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -47,7 +47,7 @@ def test_can_search(client, requests_mocker):
 
     repos_f = client.search_repository()
 
-    repos = [r for r in repos_f.result().as_iter()]
+    repos = [r for r in repos_f.result()]
 
     # It should have returned the repos as objects
     assert sorted(repos) == [Repository(id="repo1"), Repository(id="repo2")]
@@ -74,7 +74,7 @@ def test_search_retries(client, requests_mocker, caplog):
 
     repos_f = client.search_repository()
 
-    repos = [r for r in repos_f.result().as_iter()]
+    repos = [r for r in repos_f.result()]
 
     # It should have found the repo
     assert repos == [Repository(id="repo1")]

--- a/tests/fake/test_fake_search.py
+++ b/tests/fake/test_fake_search.py
@@ -280,7 +280,7 @@ def test_search_created_regex():
 
     client = controller.client
     crit = Criteria.with_field("notes.created", Matcher.regex("19-06"))
-    found = list(client.search_repository(crit).result().as_iter())
+    found = list(client.search_repository(crit).result())
 
     assert sorted(found) == [repo1, repo3]
 
@@ -298,7 +298,7 @@ def test_search_paginates():
     crit = Criteria.true()
 
     page = client.search_repository(crit).result()
-    found_repos = [repo for repo in page.as_iter()]
+    found_repos = list(page)
 
     page_count = 1
     while page.next:


### PR DESCRIPTION
Implementing `__iter__` allows to directly iterate over Page objects
rather than having to call as_iter.

The original idea with adding Page.as_iter rather than `__iter__` was
that using as_iter is blocking, and it would be better to be
explicit rather than implicit whenever operations might block, so
as to help keep a workflow entirely non-blocking.

However, now we have several pieces of code using this library and
the following pattern is seen commonly:

    repos = client.search_repository(...).result().as_iter()
    for repo in repos:
      ...

That's a bit too noisy, and this usage seems to be more common than
using search results in a non-blocking manner anyway (e.g. we usually
want to find & validate *all* repos before moving to the next step).

So, it seems like the idea of "explicit over implicit" here isn't
helping. Let's allow using the result as an iterable directly, so
above code can be written as slightly cleaner:

    repos = client.search_repository(...).result()
    for repo in repos:
      ...