### PR TITLE
Refactor models to satisfy desired invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+- **API break**: types of fields on model objects are now strictly validated
+  during construction.
+- **API break**: objects documented as immutable are now more deeply immutable;
+  it is no longer possible to mutate list fields on these objects.
+- **API break**: fixed inconsistencies on collection model fields. All fields
+  previously declared as tuples have been updated to use (immutable) lists.
+
+
+### Fixed
+- **API break**: `MaintenanceReport.last_updated`, `MaintenanceEntry.started`
+  are now `datetime` objects as documented. In previous versions, these were
+  documented as datetimes but implemented as `str`.
 
 ## [1.5.0] - 2019-09-03
 

--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -47,3 +47,4 @@ Factory = attr.Factory
 fields = attr.fields
 evolve = attr.evolve
 has = attr.has
+validators = attr.validators

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -189,7 +189,7 @@ class FakeClient(object):
             repo_id=repo_id,
             completed=True,
             succeeded=True,
-            units=tuple(removed),
+            units=removed,
         )
 
         return f_return([task])

--- a/pubtools/pulplib/_impl/model/attr.py
+++ b/pubtools/pulplib/_impl/model/attr.py
@@ -1,3 +1,5 @@
+import six
+
 from pubtools.pulplib._impl import compat_attr as attr
 
 
@@ -17,10 +19,14 @@ PULP2_PY_CONVERTER = "_pubtools.pulplib.pulp2_to_py_converter"
 PY_PULP2_CONVERTER = "_pubtools.pulplib.py_to_pulp2_converter"
 
 
-# make usage of the above less ugly
 def pulp_attrib(
     pulp_field=None, pulp_py_converter=None, py_pulp_converter=None, **kwargs
 ):
+    """Drop-in replacement for attr.ib with added features:
+
+    - applies a validator based on type automatically
+    - supports pulplib-specific metadata via extra keyword arguments
+    """
     metadata = kwargs.get("metadata") or {}
 
     if pulp_field:
@@ -31,6 +37,20 @@ def pulp_attrib(
 
     if py_pulp_converter:
         metadata[PY_PULP2_CONVERTER] = py_pulp_converter
+
+    if "type" in kwargs:
+        # As a convenience, you may define string types as type=str
+        # on any python version, but what you'll actually get is
+        # whatever's the primary string type (e.g. basestr on py2)
+        if kwargs["type"] is str:
+            kwargs["type"] = six.string_types[0]
+
+        # If you haven't defined a validator, you get one automatically
+        # for your requested type
+        if "validator" not in kwargs:
+            kwargs["validator"] = attr.validators.optional(
+                attr.validators.instance_of(kwargs["type"])
+            )
 
     kwargs["metadata"] = metadata
     return attr.ib(**kwargs)

--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -29,3 +29,7 @@ def null_convert(value):
 
 def read_timestamp(value):
     return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_timestamp(value):
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/pubtools/pulplib/_impl/model/frozenlist.py
+++ b/pubtools/pulplib/_impl/model/frozenlist.py
@@ -1,0 +1,35 @@
+class FrozenList(list):
+    # An immutable list subclass, intended for use on model fields.
+
+    # Set of overridden methods is taken from collections.abc.MutableSequence.
+
+    def __raise_immutable(self):
+        raise NotImplementedError("cannot modify immutable list")
+
+    def __setitem__(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def __delitem__(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def __iadd__(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def insert(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def append(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def extend(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def pop(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    def remove(self, *_args, **_kwargs):
+        self.__raise_immutable()
+
+    # FrozenList is hashable if everything within it is hashable
+    def __hash__(self):
+        return hash(tuple(self))

--- a/pubtools/pulplib/_impl/model/maintenance.py
+++ b/pubtools/pulplib/_impl/model/maintenance.py
@@ -6,6 +6,7 @@ import jsonschema
 
 from pubtools.pulplib._impl import compat_attr as attr
 from ..schema import load_schema
+from .frozenlist import FrozenList
 from .common import InvalidDataException
 
 
@@ -64,8 +65,8 @@ class MaintenanceReport(object):
     last_updated_by = attr.ib(default=None, type=str)
     """Person/party who updated the report last time."""
 
-    entries = attr.ib(default=attr.Factory(tuple), type=tuple)
-    """A tuple of :class:`MaintenanceEntry` objects, indicating
+    entries = attr.ib(default=attr.Factory(FrozenList), type=list, converter=FrozenList)
+    """A list of :class:`MaintenanceEntry` objects, indicating
     which repositories are in maintenance mode and details.
     If empty, then it means no repositories are in maintenance mode.
     """
@@ -105,7 +106,7 @@ class MaintenanceReport(object):
         maintenance = cls(
             last_updated=data["last_updated"],
             last_updated_by=data["last_updated_by"],
-            entries=tuple(entries),
+            entries=entries,
         )
 
         return maintenance
@@ -178,7 +179,7 @@ class MaintenanceReport(object):
 
         return attr.evolve(
             self,
-            entries=tuple(filtered_entries),
+            entries=filtered_entries,
             last_updated_by=owner,
             last_updated=iso_time_now(),
         )
@@ -208,4 +209,4 @@ class MaintenanceReport(object):
             if entry.repo_id not in repo_ids:
                 new_entries.append(entry)
 
-        return attr.evolve(self, last_updated_by=owner, entries=tuple(new_entries))
+        return attr.evolve(self, last_updated_by=owner, entries=new_entries)

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -6,6 +6,7 @@ from more_executors.futures import f_map
 from ..common import PulpObject, DetachedException
 from ..attr import pulp_attrib
 from ..distributor import Distributor
+from ..frozenlist import FrozenList
 from ...schema import load_schema
 from ... import compat_attr as attr
 
@@ -89,14 +90,15 @@ class Repository(PulpObject):
     """
 
     distributors = pulp_attrib(
-        default=attr.Factory(tuple),
-        type=tuple,
+        default=attr.Factory(FrozenList),
+        type=list,
         pulp_field="distributors",
-        pulp_py_converter=lambda ds: tuple([Distributor.from_data(d) for d in ds]),
+        converter=FrozenList,
+        pulp_py_converter=lambda ds: FrozenList([Distributor.from_data(d) for d in ds]),
         # It's too noisy to let repr descend into sub-objects
         repr=False,
     )
-    """tuple of :class:`~pubtools.pulplib.Distributor` objects belonging to this
+    """list of :class:`~pubtools.pulplib.Distributor` objects belonging to this
     repository.
     """
 
@@ -112,7 +114,9 @@ class Repository(PulpObject):
     relative_url = attr.ib(default=None, type=str)
     """Default publish URL for this repository, relative to the Pulp content root."""
 
-    mutable_urls = attr.ib(default=attr.Factory(list), type=list, hash=False)
+    mutable_urls = attr.ib(
+        default=attr.Factory(FrozenList), type=list, converter=FrozenList
+    )
     """A list of URLs relative to repository publish root which are expected
     to change at every publish (if any content of repo changed)."""
 
@@ -134,13 +138,12 @@ class Repository(PulpObject):
     """
 
     signing_keys = pulp_attrib(
-        default=attr.Factory(list),
+        default=attr.Factory(FrozenList),
         type=list,
         pulp_field="notes.signatures",
         pulp_py_converter=lambda sigs: sigs.split(","),
         py_pulp_converter=",".join,
-        converter=lambda keys: [k.strip() for k in keys],
-        hash=False,
+        converter=lambda keys: FrozenList([k.strip() for k in keys]),
     )
     """A list of GPG signing key IDs used to sign content in this repository."""
 

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from attr import validators
 from more_executors.futures import f_map
 
 from ..common import PulpObject, DetachedException
@@ -32,14 +33,14 @@ class PublishOptions(object):
     :meth:`~pubtools.pulplib.Repository.publish`.
     """
 
-    force = attr.ib(default=None, type=bool)
+    force = pulp_attrib(default=None, type=bool)
     """If True, Pulp should publish all data within a repository, rather than attempting
     to publish only changed data (or even skipping the publish).
 
     Setting ``force=True`` may have a major performance impact when publishing large repos.
     """
 
-    clean = attr.ib(default=None, type=bool)
+    clean = pulp_attrib(default=None, type=bool)
     """If True, certain publish tasks will not only publish new/changed content, but
     will also attempt to erase formerly published content which is no longer present
     in the repo.
@@ -47,7 +48,7 @@ class PublishOptions(object):
     Setting ``clean=True`` generally implies ``force=True``.
     """
 
-    origin_only = attr.ib(default=None, type=bool)
+    origin_only = pulp_attrib(default=None, type=bool)
     """If ``True``, Pulp should only update the content units / origin path on
     remote hosts.
 
@@ -111,21 +112,24 @@ class Repository(PulpObject):
     )
     """ID of the product to which this repository belongs (if any)."""
 
-    relative_url = attr.ib(default=None, type=str)
+    relative_url = pulp_attrib(default=None, type=str)
     """Default publish URL for this repository, relative to the Pulp content root."""
 
-    mutable_urls = attr.ib(
+    mutable_urls = pulp_attrib(
         default=attr.Factory(FrozenList), type=list, converter=FrozenList
     )
     """A list of URLs relative to repository publish root which are expected
     to change at every publish (if any content of repo changed)."""
 
-    is_sigstore = attr.ib(default=False, type=bool)
+    is_sigstore = pulp_attrib(default=False, type=bool)
     """True if this is a sigstore repository, used for container image manifest
     signatures."""
 
     is_temporary = pulp_attrib(
-        default=False, type=bool, pulp_field="notes.pub_temp_repo"
+        default=False,
+        type=bool,
+        validator=validators.instance_of(bool),
+        pulp_field="notes.pub_temp_repo",
     )
     """True if this is a temporary repository.
 
@@ -147,12 +151,12 @@ class Repository(PulpObject):
     )
     """A list of GPG signing key IDs used to sign content in this repository."""
 
-    skip_rsync_repodata = attr.ib(default=False, type=bool)
+    skip_rsync_repodata = pulp_attrib(default=False, type=bool)
     """True if this repository is explicitly configured such that a publish of
     this repository will not publish repository metadata to remote hosts.
     """
 
-    _client = attr.ib(default=None, init=False, repr=False, cmp=False)
+    _client = attr.ib(default=None, init=False, repr=False, cmp=False, hash=False)
     # hidden attribute for client attached to this object
 
     @property

--- a/pubtools/pulplib/_impl/model/repository/container.py
+++ b/pubtools/pulplib/_impl/model/repository/container.py
@@ -10,7 +10,7 @@ class ContainerImageRepository(Repository):
 
     type = pulp_attrib(default="docker-repo", type=str, pulp_field="notes._repo-type")
 
-    registry_id = attr.ib(
+    registry_id = pulp_attrib(
         default=attr.Factory(lambda self: self.id, takes_self=True), type=str
     )
     """The ID of this repository in a container image registry.

--- a/pubtools/pulplib/_impl/model/repository/file.py
+++ b/pubtools/pulplib/_impl/model/repository/file.py
@@ -4,6 +4,7 @@ import logging
 from more_executors.futures import f_flat_map, f_map
 
 from .base import Repository, repo_type
+from ..frozenlist import FrozenList
 from ..attr import pulp_attrib
 from ..common import DetachedException
 from ... import compat_attr as attr
@@ -29,7 +30,9 @@ class FileRepository(Repository):
     )
 
     mutable_urls = attr.ib(
-        default=attr.Factory(lambda: ["PULP_MANIFEST"]), type=list, hash=False
+        default=attr.Factory(lambda: FrozenList(["PULP_MANIFEST"])),
+        type=list,
+        converter=FrozenList,
     )
 
     def upload_file(self, file_obj, relative_url=None):

--- a/pubtools/pulplib/_impl/model/repository/file.py
+++ b/pubtools/pulplib/_impl/model/repository/file.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+from attr import validators
 from more_executors.futures import f_flat_map, f_map
 
 from .base import Repository, repo_type
@@ -27,6 +28,7 @@ class FileRepository(Repository):
             lambda self: self.id == "redhat-sigstore", takes_self=True
         ),
         type=bool,
+        validator=validators.instance_of(bool),
     )
 
     mutable_urls = attr.ib(

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -1,4 +1,5 @@
 from .base import Repository, repo_type
+from ..frozenlist import FrozenList
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
 
@@ -13,5 +14,7 @@ class YumRepository(Repository):
     type = pulp_attrib(default="rpm-repo", type=str, pulp_field="notes._repo-type")
 
     mutable_urls = attr.ib(
-        default=attr.Factory(lambda: ["repodata/repomd.xml"]), type=list, hash=False
+        default=attr.Factory(lambda: FrozenList(["repodata/repomd.xml"])),
+        type=list,
+        converter=FrozenList,
     )

--- a/pubtools/pulplib/_impl/model/task.py
+++ b/pubtools/pulplib/_impl/model/task.py
@@ -1,6 +1,7 @@
 from pubtools.pulplib._impl import compat_attr as attr
 
 from ..schema import load_schema
+from .frozenlist import FrozenList
 from .unit import Unit
 from .common import PulpObject
 from .attr import pulp_attrib
@@ -45,7 +46,10 @@ class Task(PulpObject):
     """
 
     tags = pulp_attrib(
-        default=attr.Factory(list), type=list, pulp_field="tags", hash=False
+        default=attr.Factory(FrozenList),
+        type=list,
+        converter=FrozenList,
+        pulp_field="tags",
     )
     """The tags for this task.
 
@@ -62,10 +66,13 @@ class Task(PulpObject):
     """The ID of the repository associated with this task, otherwise None."""
 
     units = pulp_attrib(
-        default=attr.Factory(tuple),
-        type=tuple,
+        default=attr.Factory(FrozenList),
+        type=FrozenList,
         pulp_field="result.units_successful",
-        pulp_py_converter=lambda raw: tuple([Unit._from_task_data(x) for x in raw]),
+        converter=FrozenList,
+        pulp_py_converter=lambda raw: FrozenList(
+            [Unit._from_task_data(x) for x in raw]
+        ),
     )
     """Info on the units which were processed as part of this task
     (e.g. associated or unassociated).
@@ -78,10 +85,10 @@ class Task(PulpObject):
     """
 
     units_data = pulp_attrib(
-        default=attr.Factory(list),
+        default=attr.Factory(FrozenList),
         type=list,
+        converter=FrozenList,
         pulp_field="result.units_successful",
-        hash=False,
     )
     """Info on the units which were processed as part of this task
     (e.g. associated or unassociated).

--- a/pubtools/pulplib/_impl/model/task.py
+++ b/pubtools/pulplib/_impl/model/task.py
@@ -16,26 +16,26 @@ class Task(PulpObject):
     id = pulp_attrib(type=str, pulp_field="task_id")
     """ID of this task (str)."""
 
-    completed = attr.ib(default=None, type=bool)
+    completed = pulp_attrib(default=None, type=bool)
     """True if this task has completed, successfully or otherwise.
 
     May be `None` if the state of this task is unknown.
     """
 
-    succeeded = attr.ib(default=None, type=bool)
+    succeeded = pulp_attrib(default=None, type=bool)
     """True if this task has completed successfully.
 
     May be `None` if the state of this task is unknown.
     """
 
-    error_summary = attr.ib(default=None, type=str)
+    error_summary = pulp_attrib(default=None, type=str)
     """A summary of the reason for this task's failure (if any).
 
     This is a short string, generally a single line, suitable for display to users.
     The string includes the ID of the failed task.
     """
 
-    error_details = attr.ib(default=None, type=str)
+    error_details = pulp_attrib(default=None, type=str)
     """Detailed information for this task's failure (if any).
 
     This may be a multi-line string and may include technical information such as
@@ -62,7 +62,7 @@ class Task(PulpObject):
          "pulp:action:publish"]
     """
 
-    repo_id = attr.ib(type=str)
+    repo_id = pulp_attrib(type=str)
     """The ID of the repository associated with this task, otherwise None."""
 
     units = pulp_attrib(

--- a/pubtools/pulplib/_impl/page.py
+++ b/pubtools/pulplib/_impl/page.py
@@ -1,12 +1,21 @@
 import logging
 import weakref
+from concurrent.futures import Future
 
 from . import compat_attr as attr
+from .model.frozenlist import FrozenList
+from .model.attr import pulp_attrib
 
 LOG = logging.getLogger("pubtools.pulplib")
 
 
-@attr.s(kw_only=True)
+# pylint shows these spurious errors on this file, not sure why:
+# page.py:86:23: E1101: Instance of '_CountingAttr' has no 'done' member (no-member)
+# Could be due to bug https://github.com/PyCQA/pylint/issues/1694 ?
+# pylint: disable=no-member
+
+
+@attr.s(kw_only=True, frozen=True)
 class Page(object):
     """A page of Pulp search results.
 
@@ -54,14 +63,16 @@ class Page(object):
 
     """
 
-    data = attr.ib(default=attr.Factory(list))
+    data = pulp_attrib(
+        default=attr.Factory(FrozenList), type=list, converter=FrozenList
+    )
     """List of Pulp objects in this page.
 
     This list will contain instances of the appropriate Pulp object type
     (e.g. :class:`~pubtools.pulplib.Repository` for a repository search).
     """
 
-    next = attr.ib(default=None)
+    next = pulp_attrib(default=None, type=Future)
     """None, if this is the last page of results.
 
     Otherwise, a Future[:class:`Page`] for the next page of results.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="1.5.0",
+    version="2.0.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -214,7 +214,7 @@ def test_non_maintenance_report(client, requests_mocker):
 
     report = client.get_maintenance_report().result()
     assert report.last_updated_by is None
-    assert report.entries == ()
+    assert report.entries == []
 
 
 def test_get_invalid_maintenance_file(client, requests_mocker, caplog):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 import json
 import pytest
 import requests_mock
@@ -201,7 +202,7 @@ def test_can_get_maintenance_report(client, requests_mocker):
     assert requests_mocker.call_count == 1
     assert isinstance(report, MaintenanceReport)
     assert report.last_updated_by == "Content Delivery"
-    assert report.last_updated == "2019-08-15T14:21:12Z"
+    assert report.last_updated == datetime.datetime(2019, 8, 15, 14, 21, 12)
     assert report.entries[0].message == "Maintenance Mode Enabled"
 
 

--- a/tests/fake/test_fake_set_maintenance.py
+++ b/tests/fake/test_fake_set_maintenance.py
@@ -28,7 +28,7 @@ def test_set_maintenance():
 
     assert isinstance(report, MaintenanceReport)
     # return an empty report
-    assert report.entries == ()
+    assert report.entries == []
     # there's no entries in the report
 
     report = report.add(repo_ids=["repo1", "repo2"])

--- a/tests/maintenance/test_maintenance.py
+++ b/tests/maintenance/test_maintenance.py
@@ -1,4 +1,5 @@
 import pytest
+import datetime
 
 from pubtools.pulplib import MaintenanceReport, MaintenanceEntry, InvalidDataException
 
@@ -18,7 +19,7 @@ def test_add_entry_existed():
         repo_id="repo1",
         owner="someone",
         message="Enabled",
-        started="2019-08-15T14:21:12Z",
+        started=datetime.datetime(2019, 8, 15, 14, 21, 12),
     )
 
     report = MaintenanceReport(entries=(entry,))

--- a/tests/model/__init__.py
+++ b/tests/model/__init__.py
@@ -1,0 +1,1 @@
+from .assertions import assert_model_invariants

--- a/tests/model/assertions.py
+++ b/tests/model/assertions.py
@@ -51,6 +51,10 @@ def assert_model_fields(model_object):
                 % (klass.__name__, field.name, field.type.__name__, model_object)
             )
 
+            if field.type is list:
+                # Any lists on our model objects should be immutable.
+                assert_list_immutable(value)
+
             # If this object is also an attrs-using class,
             # test it deeply
             if attr.has(type(value)):
@@ -92,3 +96,33 @@ def assert_type_validated(model_object, field):
         field.name,
         copy,
     )
+
+
+def assert_list_immutable(value):
+    """Verifies that a given list is immutable (all operations which would normally
+    write to the list instead raise).
+    """
+
+    with pytest.raises(NotImplementedError):
+        value[0] = None
+
+    with pytest.raises(NotImplementedError):
+        del value[0]
+
+    with pytest.raises(NotImplementedError):
+        value += None
+
+    with pytest.raises(NotImplementedError):
+        value.insert(0, None)
+
+    with pytest.raises(NotImplementedError):
+        value.append(None)
+
+    with pytest.raises(NotImplementedError):
+        value.extend([None])
+
+    with pytest.raises(NotImplementedError):
+        value.pop()
+
+    with pytest.raises(NotImplementedError):
+        value.remove(None)

--- a/tests/model/assertions.py
+++ b/tests/model/assertions.py
@@ -1,0 +1,94 @@
+import pytest
+import attr
+
+
+def assert_model_invariants(model_object):
+    """Verify that a model object (an attrs-using class) satisfies certain invariants
+    which should always be true of any model object.  These include at least:
+
+    - attrs of a defined "type" are genuinely instances of that type (or None)
+    - object is hashable
+    - object can be copied
+    - object is equal to its copy
+    - object's hash is equal to hash of its copy
+
+    This suite of assertions is meant to protect against certain mistakes which
+    can easily be made when defining an attrs-based class.
+    """
+    if model_object is None:
+        # Test trivially passes
+        return
+
+    assert_model_fields(model_object)
+
+    copy = attr.evolve(model_object)
+    assert hash(model_object) == hash(copy), "hash differs on copied object"
+    assert model_object == copy, "copied object is not equal"
+
+
+def assert_model_fields(model_object):
+    """Assert every defined field on a model object meets certain invariants:
+
+    - actual value matches declared type (or None)
+    - not possible to create a copy using wrong type for the field
+    """
+    klass = type(model_object)
+    fields = attr.fields(klass)
+
+    # Only those with a defined type are testable
+    fields = [f for f in fields if f.type]
+
+    for field in fields:
+        # Every field must have a type defined
+        assert field.type, "%s.%s is missing a type" % (klass.__name__, field.name)
+
+        value = getattr(model_object, field.name)
+        if value is not None:
+            # These tests only valid on non-None value.
+
+            assert isinstance(value, field.type), (
+                "%s.%s should be a %s but is not: %s"
+                % (klass.__name__, field.name, field.type.__name__, model_object)
+            )
+
+            # If this object is also an attrs-using class,
+            # test it deeply
+            if attr.has(type(value)):
+                assert_model_invariants(value)
+
+        # It should not be possible to create a copy of this object
+        # with a field of an incorrect type.
+        assert_type_validated(model_object, field)
+
+        # It should not be possible to directly mutate this object.
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            setattr(model_object, field.name, value)
+
+
+def assert_type_validated(model_object, field):
+    """Verify that model_object doesn't accept values of wrong type in field.
+
+    This test can find some (but not all) cases where a model fails to validate
+    that input data is of the expected type.
+    """
+
+    copy = None
+    copy_args = {field.name: object()}
+
+    # The way this test is written, it only works if the type is not
+    # declared as `object`.  It doesn't seem like there would ever
+    # be a reason to do that, but let's make sure we fail early if
+    # that does happen
+    assert field.type is not object, "test cannot handle type=object!"
+
+    try:
+        copy = attr.evolve(model_object, **copy_args)
+    except Exception:  # pylint: disable=broad-except
+        # exception is expected (we don't really care what type of exception,
+        # it's unreasonably cumbersome to force e.g. TypeError everywhere)
+        return
+
+    assert copy is None, "copying with wrong type for %s was possible! copy=%s" % (
+        field.name,
+        copy,
+    )

--- a/tests/model/test_model_assertions.py
+++ b/tests/model/test_model_assertions.py
@@ -1,0 +1,102 @@
+# This file contains tests for the model-related assertions themselves
+# to prove that the assertions aren't simply passing without verifying anything.
+import attr
+from attr import validators
+import pytest
+
+from .assertions import assert_model_invariants
+
+
+def test_wrong_type():
+    """An object with an attribute not matching defined 'type' should fail tests."""
+
+    @attr.s(frozen=True)
+    class BadType(object):
+        id = attr.ib(type=str)
+
+    instance = BadType(id=12345)
+
+    with pytest.raises(AssertionError) as exc:
+        assert_model_invariants(instance)
+
+    assert "BadType.id should be a str but is not" in str(exc.value)
+
+
+def test_unvalidated_type():
+    """An object with an attribute with unvalidated type should fail"""
+
+    @attr.s(frozen=True)
+    class Unvalidated(object):
+        my_attr = attr.ib(type=str)
+
+    instance = Unvalidated(my_attr="foo")
+
+    with pytest.raises(AssertionError) as exc:
+        assert_model_invariants(instance)
+
+    assert "copying with wrong type for my_attr was possible" in str(exc.value)
+
+
+def test_bad_hash():
+    """An object which is not hashable should fail tests."""
+
+    @attr.s(frozen=True, hash=False)
+    class BadHash(object):
+        id = attr.ib(type=str, validator=validators.instance_of(str))
+
+        def __hash__(self):
+            raise TypeError("Can't hash")
+
+    instance = BadHash(id="bad-hash")
+
+    with pytest.raises(TypeError):
+        assert_model_invariants(instance)
+
+
+def test_bad_copied_hash():
+    """An object whose copy has a different hash value will fail tests."""
+
+    callnum = []
+
+    @attr.s(frozen=True, hash=False)
+    class BadHashOnCopy(object):
+        id = attr.ib(type=str, validator=validators.instance_of(str), hash=True)
+
+        def __hash__(self):
+            callnum.append(None)
+            return hash(tuple(callnum))
+
+    instance = BadHashOnCopy(id="some-object")
+
+    with pytest.raises(AssertionError) as exc:
+        assert_model_invariants(instance)
+
+    assert "hash differs" in str(exc.value)
+
+
+def test_bad_copied_equality():
+    """An object whose copy is not equal to the original will fail tests."""
+
+    @attr.s(init=False, hash=False, frozen=True)
+    class BadCopy(object):
+        some_attr = attr.ib(
+            default=None,
+            type=str,
+            validator=validators.optional(validators.instance_of(str)),
+        )
+
+        def __init__(self, some_attr):
+            # Handle this argument oddly so that copying this class
+            # doesn't actually get you a plain copy
+            self.__dict__["some_attr"] = some_attr + "-suffix"
+
+        def __hash__(self):
+            # to make it get past the hash check
+            return 0
+
+    instance = BadCopy(some_attr="abc")
+
+    with pytest.raises(AssertionError) as exc:
+        assert_model_invariants(instance)
+
+    assert "copied object is not equal" in str(exc.value)

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -9,40 +9,10 @@ import pubtools.pulplib
 from .assertions import assert_model_invariants
 
 
-# These are some classes which currently fail the model tests.
-XFAIL_CLASSES = [
-    pubtools.pulplib.Page,
-    pubtools.pulplib.ContainerImageRepository,
-    pubtools.pulplib.Distributor,
-    pubtools.pulplib.FileRepository,
-    pubtools.pulplib.FileUnit,
-    pubtools.pulplib.MaintenanceEntry,
-    pubtools.pulplib.MaintenanceReport,
-    pubtools.pulplib.ModulemdUnit,
-    pubtools.pulplib.PublishOptions,
-    pubtools.pulplib.Repository,
-    pubtools.pulplib.RpmUnit,
-    pubtools.pulplib.Task,
-    pubtools.pulplib.Unit,
-    pubtools.pulplib.YumRepository,
-]
-
-
 def test_invariants(model_object):
     """Test that the given object satisfies all expected invariants of model objects."""
 
-    # Checking for *exact* types is intentional here to limit scope of xfail:
-    # pylint: disable=unidiomatic-typecheck
-
-    try:
-        assert_model_invariants(model_object)
-    except:
-        if type(model_object) in XFAIL_CLASSES:
-            pytest.xfail("class is known to be buggy")
-        raise
-
-    # If it didn't fail, it must not be listed in XFAIL
-    assert type(model_object) not in XFAIL_CLASSES
+    assert_model_invariants(model_object)
 
 
 def public_model_objects():

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -1,0 +1,126 @@
+import datetime
+
+import attr
+import sys
+import pytest
+
+import pubtools.pulplib
+
+from .assertions import assert_model_invariants
+
+
+# These are some classes which currently fail the model tests.
+XFAIL_CLASSES = [
+    pubtools.pulplib.Page,
+    pubtools.pulplib.ContainerImageRepository,
+    pubtools.pulplib.Distributor,
+    pubtools.pulplib.FileRepository,
+    pubtools.pulplib.FileUnit,
+    pubtools.pulplib.MaintenanceEntry,
+    pubtools.pulplib.MaintenanceReport,
+    pubtools.pulplib.ModulemdUnit,
+    pubtools.pulplib.PublishOptions,
+    pubtools.pulplib.Repository,
+    pubtools.pulplib.RpmUnit,
+    pubtools.pulplib.Task,
+    pubtools.pulplib.Unit,
+    pubtools.pulplib.YumRepository,
+]
+
+
+def test_invariants(model_object):
+    """Test that the given object satisfies all expected invariants of model objects."""
+
+    # Checking for *exact* types is intentional here to limit scope of xfail:
+    # pylint: disable=unidiomatic-typecheck
+
+    try:
+        assert_model_invariants(model_object)
+    except:
+        if type(model_object) in XFAIL_CLASSES:
+            pytest.xfail("class is known to be buggy")
+        raise
+
+    # If it didn't fail, it must not be listed in XFAIL
+    assert type(model_object) not in XFAIL_CLASSES
+
+
+def public_model_objects():
+    """Returns a default-constructed instance of every public model class
+    found in pubtools.pulplib.
+    """
+    public_symbols = dir(pubtools.pulplib)
+    public_symbols = [sym for sym in public_symbols if not sym.startswith("_")]
+
+    public_classes = [getattr(pubtools.pulplib, sym) for sym in public_symbols]
+    public_classes = [klass for klass in public_classes if attr.has(klass)]
+
+    return [default_object(klass) for klass in public_classes]
+
+
+def default_for_field(field):
+    # Certain fields with known strict semantics
+    value_by_name = {"sha256sum": "a" * 64, "sha1sum": "b" * 40, "md5sum": "c" * 32}
+
+    # Generic defaults for certain types
+    value_by_type = {
+        str: "test",
+        int: 123,
+        datetime.datetime: datetime.datetime(2019, 9, 4, 12, 9, 30),
+    }
+
+    if sys.version_info.major == 2:
+        value_by_type[basestring] = "test"
+
+    if field.name in value_by_name:
+        return value_by_name[field.name]
+    if field.type in value_by_type:
+        return value_by_type[field.type]
+
+    # Try a default-constructed object.
+    return field.type()
+
+
+def all_fields(klass):
+    """Returns all attr fields on klass and all base classes."""
+    out = attr.fields(klass)
+    for base in klass.__bases__:
+        if attr.has(base):
+            out = out + attr.fields(base)
+    return out
+
+
+def default_object(klass):
+    """Return an instance of attrs-using klass, constructed with minimal arguments.
+    This means:
+
+    - any fields with a declared default will use that default
+    - any other fields have basic defaults injected
+    """
+    args = {}
+
+    for field in all_fields(klass):
+        if field.default is not attr.NOTHING:
+            # There's a default, then no arg needed
+            continue
+        if field.name.startswith("_"):
+            # Internal field
+            continue
+        if field.name in args:
+            # Already calculated field from a derived class,
+            # no need to recalculate for base
+            continue
+        if not field.type:
+            # No type declared, try None as default
+            args[field.name] = None
+        else:
+            args[field.name] = default_for_field(field)
+
+    return klass(**args)
+
+
+@pytest.fixture(params=public_model_objects(), ids=lambda object: type(object).__name__)
+def model_object(request):
+    """This fixture yields an object for every public attrs-using class
+    in the library."""
+    yield request.param

--- a/tests/repository/test_repository_from_data.py
+++ b/tests/repository/test_repository_from_data.py
@@ -68,10 +68,10 @@ def test_distributors_created():
         }
     )
 
-    assert repo.distributors == (
+    assert repo.distributors == [
         Distributor(id="dist1", type_id="type1"),
         Distributor(id="dist2", type_id="type1"),
-    )
+    ]
 
 
 def test_distributors_last_publish():


### PR DESCRIPTION
Our model classes had various bugs and weaknesses.  This pull request
fixes them and adds tests to ensure that the same mistakes can't happen
on new classes.

The original motivation here was to fix up inconsistent usage of tuples vs lists
for immutability, but testing found several additional bugs to be fixed, most
notably that the recently added maintenance classes had fields using an
entirely different type than what was declared in the model.

The changes made here include:

- added tests which verify that *all* public attrs-using classes meet certain invariants,
  such as "actual types match declared types" and "all fields are immutable"
- added a FrozenList immutable list type and used that for all model fields which were
  formerly using tuples or plain lists
- fix incorrect implementations of Maintenance classes which used wrong types
- make Page immutable too (seems like an oversight that it wasn't already)
- bump version to 2.0.0 because these changes are not strictly backwards-compatible
  (although I doubt that any current users are affected).

More information on each of these changes can be found in the commit messages.