### PR TITLE
Fix 'Double requirement given: six'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ six
 PyYAML
 jsonschema
 attrs
-six


### PR DESCRIPTION
There are duplicate 'six' in requirements.txt.
Remove one of them.