### PR TITLE
User should be able to search distributors by relative_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- Added a new attribute a`relative_url` to `Distributor`, so users can search distributors
+  by relative_url
 
 ## [2.1.0] - 2019-09-10
 

--- a/pubtools/pulplib/_impl/model/distributor.py
+++ b/pubtools/pulplib/_impl/model/distributor.py
@@ -29,6 +29,10 @@ class Distributor(PulpObject):
     repo_id = pulp_attrib(type=str, default=None, pulp_field="repo_id")
     """The :class:`pubtools.pulplib.Repository` ID this distributor is attached to."""
 
+    relative_url = pulp_attrib(type=str, default=None, pulp_field="config.relative_url")
+    """Default distribution URL for the repository which the distributor is attached to,
+    relative to the Pulp content root."""
+
     last_publish = pulp_attrib(
         default=None, type=datetime.datetime, pulp_field="last_publish"
     )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.1.0",
+    version="2.2.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake_search.py
+++ b/tests/fake/test_fake_search.py
@@ -367,6 +367,43 @@ def test_search_distributor():
     assert sorted(found) == [dist2, dist1]
 
 
+def test_search_distributor_with_relative_url():
+    controller = FakeController()
+
+    dist1 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="repo1",
+        relative_url="relative/path",
+    )
+    dist2 = Distributor(
+        id="cdn_distributor",
+        type_id="rpm_rsync_distributor",
+        repo_id="repo1",
+        relative_url="relative/path",
+    )
+    repo1 = Repository(id="repo1", distributors=(dist1, dist2))
+
+    dist3 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="repo2",
+        relative_url="another/path",
+    )
+
+    repo2 = Repository(id="repo2", distributors=(dist3,))
+
+    controller.insert_repository(repo1)
+    controller.insert_repository(repo2)
+
+    client = controller.client
+    crit = Criteria.with_field("relative_url", Matcher.regex("relative/path"))
+
+    found = client.search_distributor(crit).result().data
+
+    assert sorted(found) == [dist2, dist1]
+
+
 def test_search_mapped_field_less_than():
     controller = FakeController()
 


### PR DESCRIPTION
Add a new attribute, relative_url, to Distributor, which makes it
possible to search distributors by relative_url.