### PR TITLE
minor bug fix and rewrite set-maintenance example script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fixed minor bug in map_404_to_none, where the response could have response equals to None
-- rewrite set-maintenace example, make it more realistic
+- Fixed certain exceptions from requests library not being propagated properly while
+  getting maintenance report.
 
 ## [2.3.0] - 2019-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fixed minor bug in map_404_to_none, where the response could have response equals to None
+- rewrite set-maintenace example, make it more realistic
 
 ## [2.3.0] - 2019-09-25
 

--- a/examples/set-maintenance
+++ b/examples/set-maintenance
@@ -13,11 +13,11 @@ def set_maintenance(client, regex):
 
     report = client.get_maintenance_report().result()
 
-    crit = Criteria.with_field("id", Matcher.regex(regex))
-    # search repo
-    repos = client.search_repository(crit).result()
+    crit = Criteria.with_field("relative_url", Matcher.regex(regex))
+    # search repos by distributor's relative_url
+    distributors = client.search_distributor(crit).result()
 
-    repo_ids = [repo.id for repo in repos]
+    repo_ids = [dist.repo_id for dist in distributors]
     report = report.add(repo_ids)
     # get the repo ids and feed to report
 
@@ -26,13 +26,8 @@ def set_maintenance(client, regex):
     report = client.get_maintenance_report().result()
     log.info("maintenance mode set: %s", report.entries)
 
-    to_remove = []
-    for entry in report.entries:
-        if re.match(regex, entry.id):
-            to_remove.append(entry.id)
-
-    report = report.remove(to_remove)
-    tasks = client.set_maintainenance(report).result()
+    report = report.remove(repo_ids)
+    tasks = client.set_maintenance(report).result()
 
     report = client.get_maintenance_report().result()
     log.info("maintenance mode unset: %s", report.entries)
@@ -64,22 +59,22 @@ def main():
     )
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--insecure", default=False, action="store_true")
-    parser.add_argument("--regex", action="store")
+    parser.add_argument("--repo-url-regex", action="store")
 
     p = parser.parse_args()
 
     if not p.url:
         parser.error("--url is required")
 
-    if not p.regex:
-        parser.error("--regex is required")
+    if not p.repo_url_regex:
+        parser.error("--repo-url-regex is required")
 
     if p.debug:
         logging.getLogger("pubtools.pulplib").setLevel(logging.DEBUG)
         log.setLevel(logging.DEBUG)
 
     client = make_client(p)
-    return set_maintenance(client, p.regex)
+    return set_maintenance(client, p.repo_url_regex)
 
 
 if __name__ == "__main__":

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -514,7 +514,10 @@ class Client(object):
     def _do_get_maintenance(self):
         def map_404_to_none(exception):
             # Translates 404 errors to a None response (no maintenance report).
-            if hasattr(exception, "response") and exception.response.status_code == 404:
+            if (
+                getattr(exception, "response", None) is not None
+                and exception.response.status_code == 404
+            ):
                 return None
             # Any other types of errors are raised unchanged.
             raise exception

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.3.0",
+    version="2.3.1",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",


### PR DESCRIPTION
Now the set-maintenance script example takes the --repo-url-regex
option and set maintenance mode on based on the relative_url, instead
of id when this option is used.

Also, fix a minor bug get_maintenance map_404_to_non callback, which
the response could be None.