### PR TITLE
Fix export an empty maintenance would crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fixed a bug that export an empty maintenance report would crash.
 
 ## [2.3.1] - 2019-10-03
 

--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -32,4 +32,7 @@ def read_timestamp(value):
 
 
 def write_timestamp(value):
+    # value could be None if the report is empty
+    if value is None:
+        value = datetime.datetime.utcnow()
     return value.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -32,7 +32,7 @@ def read_timestamp(value):
 
 
 def write_timestamp(value):
-    # value could be None if the report is empty
+    # defaults to current time if value is None
     if value is None:
         value = datetime.datetime.utcnow()
     return value.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.3.1",
+    version="2.3.2",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/maintenance/test_maintenance.py
+++ b/tests/maintenance/test_maintenance.py
@@ -50,7 +50,7 @@ def test_load_invalid_report_raise_exception():
 
 def test_create_export_report():
     data = {
-        "last_updated": "2019-08-15T14:21:12Z",  # invalid timestamp
+        "last_updated": "2019-08-15T14:21:12Z",
         "last_updated_by": "pubtools.pulplib",
         "repos": {
             "repo1": {
@@ -70,7 +70,7 @@ def test_create_export_report():
 
 def test_report_add_remove():
     data = {
-        "last_updated": "2019-08-15T14:21:12Z",  # invalid timestamp
+        "last_updated": "2019-08-15T14:21:12Z",
         "last_updated_by": "pubtools.pulplib",
         "repos": {
             "repo1": {
@@ -92,3 +92,14 @@ def test_report_add_remove():
 
     assert len(report.entries) == 1
     assert report.last_updated_by == "jazhang"
+
+
+def test_export_empty_report():
+    # create an empty report with out data passed
+    report = MaintenanceReport()
+    assert report.last_updated is None
+
+    # export empty report shouldn't have problem
+    data = report._export_dict()
+    # exported report should have a timestamp
+    assert datetime.datetime.strptime(data["last_updated"], "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Now if the report is empty and last_updated field is None, then while
exporting report, current datetime will be used to aviod crashing.