### PR TITLE
Revise new search_content API

### DIFF
--- a/examples/search-repo-content
+++ b/examples/search-repo-content
@@ -49,13 +49,15 @@ def main():
     repository = client.get_repository(p.repo_id)
     units = repository.search_content(type_id=p.content_type)
 
-    if units:
-        log.info(
-            "Found %s %s units: \n\t%s"
-            % (len(units), p.content_type, "\n\t".join(str(unit) for unit in units))
-        )
+    count = 0
+    for unit in units:
+        log.info("\t%s", unit)
+        count += 1
+
+    if count:
+        log.info("Found %s %s units", count, p.content_type)
     else:
-        log.info("No %s units found." % p.content_type)
+        log.info("No %s units found.", p.content_type)
 
     return units
 

--- a/examples/search-repo-content
+++ b/examples/search-repo-content
@@ -31,7 +31,9 @@ def main():
     )
     parser.add_argument("--url", help="Pulp server URL", required=True)
     parser.add_argument("--username", help="Pulp username")
-    parser.add_argument("--password", help="Pulp password (or set PULP_PASSWORD in env)")
+    parser.add_argument(
+        "--password", help="Pulp password (or set PULP_PASSWORD in env)"
+    )
     parser.add_argument("--repo-id", action="store", required=True)
     parser.add_argument("--content-type", action="store", required=True)
     parser.add_argument("--debug", action="store_true")
@@ -48,10 +50,10 @@ def main():
     units = repository.search_content(type_id=p.content_type)
 
     if units:
-        log.info("Found %s %s units: \n\t%s" % (
-            len(units), p.content_type,
-            "\n\t".join(str(unit) for unit in units)
-        ))
+        log.info(
+            "Found %s %s units: \n\t%s"
+            % (len(units), p.content_type, "\n\t".join(str(unit) for unit in units))
+        )
     else:
         log.info("No %s units found." % p.content_type)
 

--- a/examples/search-repo-content
+++ b/examples/search-repo-content
@@ -3,7 +3,7 @@ import os
 import logging
 from argparse import ArgumentParser
 
-from pubtools.pulplib import Client
+from pubtools.pulplib import Client, Criteria
 
 log = logging.getLogger("search-repo-content")
 
@@ -47,7 +47,9 @@ def main():
 
     client = make_client(p)
     repository = client.get_repository(p.repo_id)
-    units = repository.search_content(type_id=p.content_type)
+    units = repository.search_content(
+        Criteria.with_field("content_type_id", p.content_type)
+    )
 
     count = 0
     for unit in units:

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -265,6 +265,13 @@ class Client(object):
             )
         )
 
+    def _search_repo_units(self, repo_id, criteria):
+        resource_type = "repositories/%s" % repo_id
+
+        return self._search(
+            Unit, resource_type, search_type="search/units", criteria=criteria
+        )
+
     def get_maintenance_report(self):
         """Get the current maintenance mode status for this Pulp server.
 

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -21,7 +21,7 @@ from pubtools.pulplib import (
     Distributor,
     MaintenanceReport,
 )
-from pubtools.pulplib._impl.client.search import filters_for_criteria
+from pubtools.pulplib._impl.client.search import search_for_criteria
 from .. import compat_attr as attr
 
 from .match import match_object
@@ -76,7 +76,7 @@ class FakeClient(object):
         # we're not accessing a real Pulp server. The point is to ensure the
         # same validation and error behavior as used by the real client also
         # applies to the fake.
-        filters_for_criteria(criteria, Repository)
+        search_for_criteria(criteria, Repository)
 
         try:
             for repo in self._repositories:
@@ -94,7 +94,7 @@ class FakeClient(object):
         criteria = criteria or Criteria.true()
         distributors = []
 
-        filters_for_criteria(criteria, Distributor)
+        search_for_criteria(criteria, Distributor)
 
         try:
             for repo in self._repositories:

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -194,8 +194,8 @@ class Repository(PulpObject, Deletable):
         return self._distributors_by_id.get(distributor_id)
 
     @property
-    def iso_content(self):
-        """A list of iso units stored in this repository.
+    def file_content(self):
+        """A list of file units stored in this repository.
 
         Returns:
             list[:class:`~pubtools.pulplib.FileUnit`]

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -273,11 +273,7 @@ class Repository(PulpObject, Deletable):
         if not self._client:
             raise DetachedException()
 
-        resource_type = "repositories/%s" % self.id
-
-        return self._client._search(
-            Unit, resource_type, search_type="search/units", criteria=criteria
-        )
+        return self._client._search_repo_units(self.id, criteria)
 
     def delete(self):
         """Delete this repository from Pulp.

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -202,7 +202,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return self.search_content("iso")
+        return list(self.search_content("iso"))
 
     @property
     def rpm_content(self):
@@ -213,7 +213,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return self.search_content("rpm")
+        return list(self.search_content("rpm"))
 
     @property
     def srpm_content(self):
@@ -224,7 +224,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return self.search_content("srpm")
+        return list(self.search_content("srpm"))
 
     @property
     def modulemd_content(self):
@@ -235,7 +235,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return self.search_content("modulemd")
+        return list(self.search_content("modulemd"))
 
     @property
     def modulemd_defaults_content(self):
@@ -246,7 +246,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return self.search_content("modulemd_defaults")
+        return list(self.search_content("modulemd_defaults"))
 
     def search_content(self, type_id, criteria=None):
         """Search this repository for content matching the given criteria.
@@ -258,9 +258,11 @@ class Repository(PulpObject, Deletable):
                 A criteria object used for this search.
 
         Returns:
-            list[:class:`~pubtools.pulplib.Unit`]
-                A list of zero or more :class:`~pubtools.pulplib.Unit`
-                subclasses found by the search operation.
+            Future[:class:`~pubtools.pulplib.Page`]
+                A future representing the first page of results.
+
+                Each page will contain a collection of
+                :class:`~pubtools.pulplib.Unit` objects.
 
         .. versionadded:: 2.4.0
         """
@@ -269,10 +271,8 @@ class Repository(PulpObject, Deletable):
 
         resource_type = "repositories/%s" % self.id
         search_options = {"type_ids": type_id}
-        return list(
-            self._client._search(
-                Unit, resource_type, criteria=criteria, search_options=search_options
-            )
+        return self._client._search(
+            Unit, resource_type, criteria=criteria, search_options=search_options
         )
 
     def delete(self):

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -12,7 +12,7 @@ from ..common import (
 from ..attr import pulp_attrib
 from ..distributor import Distributor
 from ..frozenlist import FrozenList
-from ..unit import Unit
+from ...criteria import Criteria
 from ...schema import load_schema
 from ... import compat_attr as attr
 
@@ -202,7 +202,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return list(self.search_content("iso"))
+        return list(self.search_content(Criteria.with_field("content_type_id", "iso")))
 
     @property
     def rpm_content(self):
@@ -213,7 +213,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return list(self.search_content("rpm"))
+        return list(self.search_content(Criteria.with_field("content_type_id", "rpm")))
 
     @property
     def srpm_content(self):
@@ -224,7 +224,7 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return list(self.search_content("srpm"))
+        return list(self.search_content(Criteria.with_field("content_type_id", "srpm")))
 
     @property
     def modulemd_content(self):
@@ -235,7 +235,9 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return list(self.search_content("modulemd"))
+        return list(
+            self.search_content(Criteria.with_field("content_type_id", "modulemd"))
+        )
 
     @property
     def modulemd_defaults_content(self):
@@ -246,14 +248,16 @@ class Repository(PulpObject, Deletable):
 
         .. versionadded:: 2.4.0
         """
-        return list(self.search_content("modulemd_defaults"))
+        return list(
+            self.search_content(
+                Criteria.with_field("content_type_id", "modulemd_defaults")
+            )
+        )
 
-    def search_content(self, type_id, criteria=None):
+    def search_content(self, criteria=None):
         """Search this repository for content matching the given criteria.
 
         Args:
-            type_id (str)
-                The content type to search
             criteria (:class:`~pubtools.pulplib.Criteria`)
                 A criteria object used for this search.
 
@@ -270,9 +274,9 @@ class Repository(PulpObject, Deletable):
             raise DetachedException()
 
         resource_type = "repositories/%s" % self.id
-        search_options = {"type_ids": type_id}
+
         return self._client._search(
-            Unit, resource_type, criteria=criteria, search_options=search_options
+            Unit, resource_type, search_type="search/units", criteria=criteria
         )
 
     def delete(self):

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -6,7 +6,6 @@ from pubtools.pulplib import Criteria, Matcher
 from pubtools.pulplib._impl.client.search import (
     filters_for_criteria,
     field_match,
-    validate_type_ids,
 )
 
 
@@ -101,25 +100,3 @@ def test_dict_matcher_value():
     assert filters_for_criteria(crit) == {
         "created": {"$lt": {"created_date": {"$date": "2019-09-04T00:00:00Z"}}}
     }
-
-
-def test_valid_type_ids(caplog):
-    assert validate_type_ids(["srpm", "iso", "quark", "rpm"]) == ["srpm", "iso", "rpm"]
-    for m in ["Invalid content type ID(s):", "quark"]:
-        assert m in caplog.text
-
-
-def test_invalid_type_ids():
-    """validate_type_ids raises if called without valid criteria"""
-    with pytest.raises(ValueError) as e:
-        validate_type_ids("quark")
-
-    assert "Must provide valid content type ID(s)" in str(e)
-
-
-def test_invalid_type_ids_type():
-    """validate_type_ids raises if called without valid criteria"""
-    with pytest.raises(TypeError) as e:
-        validate_type_ids({"srpm": "some-srpm"})
-
-    assert "Expected str, list, or tuple, got %s" % type({}) in str(e)

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -1,0 +1,126 @@
+import pytest
+
+from pubtools.pulplib import (
+    FakeController,
+    Criteria,
+    Matcher,
+    RpmUnit,
+    ModulemdUnit,
+    YumRepository,
+)
+
+
+@pytest.fixture
+def controller():
+    return FakeController()
+
+
+@pytest.fixture
+def populated_repo(controller):
+    units = [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(
+            content_type_id="srpm", name="bash", version="4.0", release="1", arch="src"
+        ),
+        RpmUnit(name="glibc", version="5.0", release="1", arch="x86_64"),
+        ModulemdUnit(
+            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+        ),
+        ModulemdUnit(
+            name="module2", stream="s2", version=1234, context="a1b2", arch="x86_64"
+        ),
+    ]
+
+    repo = YumRepository(id="repo1")
+    controller.insert_repository(repo)
+    controller.insert_units(repo, units)
+
+    return controller.client.get_repository(repo.id).result()
+
+
+def test_search_content_empty_repo(controller):
+    """search_content on empty repo gives no results"""
+    repo = YumRepository(id="empty-repo")
+    controller.insert_repository(repo)
+
+    assert list(controller.client.get_repository("empty-repo").search_content()) == []
+
+
+def test_search_content_missing_repo(controller, populated_repo):
+    """search_content on nonexistent repo raises"""
+    # Get an additional reference to the same repo
+    repo = controller.client.get_repository("repo1")
+
+    # Now delete the repo through one reference
+    populated_repo.delete().result()
+
+    # Searching through the other reference should now return a failed future
+    # with reasonable error
+    assert "Repository id=repo1 not found" in str(repo.search_content().exception())
+
+
+def test_search_content_unsupported_operator(populated_repo):
+    """search_content using unsupported operators on content_type_id raises"""
+    with pytest.raises(ValueError) as e:
+        populated_repo.search_content(
+            Criteria.with_field("content_type_id", Matcher.regex("foobar"))
+        )
+
+    assert "unsupported expression for content_type_id" in str(e.value)
+
+
+def test_search_null_and(populated_repo):
+    """Search with an empty AND gives an error."""
+    crit = Criteria.and_()
+    assert "Invalid AND in search query" in str(
+        populated_repo.search_content(crit).exception()
+    )
+
+
+def test_search_content_default_crit(populated_repo):
+    """search_content with default criteria on populated repo finds all units"""
+
+    units = list(populated_repo.search_content())
+    assert len(units) == 5
+
+
+def test_search_content_by_type(populated_repo):
+    """search_content for particular type returns matching content"""
+
+    crit = Criteria.with_field("content_type_id", "rpm")
+    units = list(populated_repo.search_content(crit))
+    assert sorted(units) == [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(name="glibc", version="5.0", release="1", arch="x86_64"),
+    ]
+
+
+def test_search_content_by_unit_field(populated_repo):
+    """search_content on regular field returns matching content"""
+
+    crit = Criteria.with_field("name", "bash")
+    units = list(populated_repo.search_content(crit))
+    assert sorted(units) == [
+        RpmUnit(
+            content_type_id="srpm", name="bash", version="4.0", release="1", arch="src"
+        ),
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+    ]
+
+
+def test_search_content_mixed_fields(populated_repo):
+    """search_content crossing multiple fields and types returns matching units"""
+
+    crit = Criteria.and_(
+        Criteria.with_field_in("content_type_id", ["rpm", "modulemd"]),
+        Criteria.with_field_in("name", ["bash", "module1"]),
+    )
+    units = list(populated_repo.search_content(crit))
+
+    # Note: sorting different types not natively supported, hence sorting by repr
+    assert sorted(units, key=repr) == [
+        ModulemdUnit(
+            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+        ),
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+    ]

--- a/tests/repository/test_search_content.py
+++ b/tests/repository/test_search_content.py
@@ -5,11 +5,11 @@ from pubtools.pulplib import Repository, DetachedException
 def test_detached():
     """content searches raise if called on a detached repository object"""
     with pytest.raises(DetachedException):
-        assert not Repository(id="some-repo").iso_content
+        assert not Repository(id="some-repo").file_content
 
 
-def test_iso_content(client, requests_mocker):
-    """iso_content returns correct unit types"""
+def test_file_content(client, requests_mocker):
+    """file_content returns correct unit types"""
     repo = Repository(id="some-repo")
     repo.__dict__["_client"] = client
     requests_mocker.post(
@@ -26,10 +26,10 @@ def test_iso_content(client, requests_mocker):
         ],
     )
 
-    isos = repo.iso_content
+    files = repo.file_content
 
-    assert len(isos) == 1
-    assert isos[0].content_type_id == "iso"
+    assert len(files) == 1
+    assert files[0].content_type_id == "iso"
 
 
 def test_rpm_content(client, requests_mocker):

--- a/tests/repository/test_search_content.py
+++ b/tests/repository/test_search_content.py
@@ -1,11 +1,86 @@
 import pytest
-from pubtools.pulplib import Repository, DetachedException
+from pubtools.pulplib import Repository, DetachedException, Criteria, Matcher, FileUnit
 
 
 def test_detached():
     """content searches raise if called on a detached repository object"""
     with pytest.raises(DetachedException):
         assert not Repository(id="some-repo").file_content
+
+
+def test_complex_type_ids(client):
+    """content searches raise if using criteria with unsupported operators on content_type_id"""
+    repo = Repository(id="some-repo")
+    repo.__dict__["_client"] = client
+
+    with pytest.raises(ValueError) as e:
+        repo.search_content(
+            Criteria.with_field("content_type_id", Matcher.regex("foobar"))
+        )
+
+    assert "unsupported expression for content_type_id" in str(e.value)
+
+
+def test_mixed_search(client, requests_mocker):
+    """Searching with a criteria mixing several fields works correctly"""
+    repo = Repository(id="some-repo")
+    repo.__dict__["_client"] = client
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/search/units/",
+        json=[
+            {
+                "metadata": {
+                    "_content_type_id": "iso",
+                    "name": "hello.txt",
+                    "size": 23,
+                    "checksum": "a" * 64,
+                }
+            }
+        ],
+    )
+
+    crit = Criteria.and_(
+        Criteria.with_field_in("content_type_id", ["rpm", "iso"]),
+        Criteria.with_field("name", "hello.txt"),
+    )
+
+    files = list(repo.search_content(crit))
+
+    assert files == [FileUnit(path="hello.txt", size=23, sha256sum="a" * 64)]
+
+    history = requests_mocker.request_history
+
+    # There should have been just one request
+    assert len(history) == 1
+
+    request = history[0]
+    body = request.json()
+
+    # This should have been the request body.
+    assert body == {
+        "criteria": {
+            "type_ids": ["rpm", "iso"],
+            "skip": 0,
+            "limit": 2000,
+            "filters": {"unit": {"name": {"$eq": "hello.txt"}}},
+        }
+    }
+
+
+def test_search_content_type_id_in_or(client, requests_mocker):
+    """Searching with a content_type_id within $or fails as unsupported"""
+    repo = Repository(id="some-repo")
+    repo.__dict__["_client"] = client
+
+    crit = Criteria.or_(
+        Criteria.with_field("name", "hello.txt"),
+        Criteria.with_field_in("content_type_id", ["rpm", "iso"]),
+    )
+
+    with pytest.raises(ValueError) as e:
+        repo.search_content(crit).result()
+
+    assert "Can't serialize criteria for Pulp query; too complicated" in str(e.value)
 
 
 def test_file_content(client, requests_mocker):


### PR DESCRIPTION
This PR includes various revisions to the recently added Repository.search_content API.

In summary, the changes include:

- API change: search_content should return a Future (like other search methods), not a list
- API change: use the term "file" instead of "iso" for generic file units
- API change: remove type_id, use criteria instead
- Add the missing implementation for FakeClient

More detailed explanations can be found in the PR's commits.