### PR TITLE
Feature/add copy repo method

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -316,16 +316,20 @@ class Client(object):
 
         return f_flat_map(upload_ft, lambda _: repo.publish())
 
-    def copy_repo_content(self, origin_repo, dest_repo):
+    def copy_repo_content(self, origin_repo, dest_repo, criteria=None, override_config=None):
         url = os.path.join(
             self._url,
             "pulp/api/v2/repositories/%s/actions/associate/" % dest_repo
         )
 
-        body = {"source_repo_id": origin_repo}
+        data = {"source_repo_id": origin_repo}
+        if criteria:
+            data['criteria'] = criteria
+        if override_config:
+            data['override_config'] = override_config
 
         return self._task_executor.submit(
-            self._do_request, method="POST", url=url, json=body
+            self._do_request, method="POST", url=url, json=data
         )
 
     def get_content_type_ids(self):

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -317,6 +317,21 @@ class Client(object):
         return f_flat_map(upload_ft, lambda _: repo.publish())
 
     def copy_repo_content(self, origin_repo, dest_repo, criteria=None, override_config=None):
+        """
+        Args:
+            origin_repo:
+                String of the origin repo name
+            dest_repo:
+                String of the destination repo name
+            criteria:
+                optional Criteria object with filter parameters
+            override_config:
+                optional dictionary to override configuration options
+        Return:
+            Future[list[:class:`~pubtools.pulplib.Task`]]
+                A future which is resolved when the packages have been copied 
+                to the destination repo
+        """
         url = os.path.join(
             self._url,
             "pulp/api/v2/repositories/%s/actions/associate/" % dest_repo

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -316,6 +316,18 @@ class Client(object):
 
         return f_flat_map(upload_ft, lambda _: repo.publish())
 
+    def copy_repo_content(self, origin_repo, dest_repo):
+        url = os.path.join(
+            self._url,
+            "pulp/api/v2/repositories/%s/actions/associate/" % dest_repo
+        )
+
+        body = {"source_repo_id": origin_repo}
+
+        return self._task_executor.submit(
+            self._do_request, method="POST", url=url, json=body
+        )
+
     def get_content_type_ids(self):
         """Get the content types supported by this Pulp server.
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.4.0",
+    version="2.4.1",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",


### PR DESCRIPTION
Adds a method to copy content from one Pulp repo to another. I noticed there is an open issue to add this ability and I ran into this limitation when attempting to manage Python dependencies between environments when using Pulp.

I'm not too familiar with this code base so any suggestions to improve are appreciated. Also still need to add some tests to the suite for this method.