### PR TITLE
Fix wrongly mandatory fields for modulemd_defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sourcerpm attribute for Rpm unit
 - Introduced 'population_sources' and 'ubi_population' attributes for yum repository
 
+### Fixed
+- 'stream' and 'profiles' are now optional on modulemd_defaults units, rather
+  than incorrectly mandatory (leading to schema validation errors)
+
 ## [2.5.0] - 2020-02-25
 
 ### Added

--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -15,14 +15,11 @@ class ModulemdDefaultsUnit(Unit):
     name = pulp_attrib(type=str, pulp_field="name")
     """The name of this modulemd defaults unit"""
 
-    stream = pulp_attrib(type=str, pulp_field="stream")
-    """The stream of this modulemd defaults unit"""
-
     repo_id = pulp_attrib(type=str, pulp_field="repo_id")
     """The repository ID bound to this modulemd defaults unit"""
 
-    profiles = pulp_attrib(pulp_field="profiles")
-    """The profiles of this modulemd defaults unit.
+    stream = pulp_attrib(type=str, pulp_field="stream", default=None)
+    """The stream of this modulemd defaults unit"""
 
-    The type for this attribute is omitted to allow for either dict or None.
-    """
+    profiles = pulp_attrib(type=dict, pulp_field="profiles", default=None)
+    """The profiles of this modulemd defaults unit."""

--- a/pubtools/pulplib/_impl/schema/unit.yaml
+++ b/pubtools/pulplib/_impl/schema/unit.yaml
@@ -144,7 +144,6 @@ definitions:
     required:
     - _content_type_id
     - name
-    - stream
     - repo_id
 
   # Schema for any unknown type of unit

--- a/tests/repository/test_search_content.py
+++ b/tests/repository/test_search_content.py
@@ -198,7 +198,6 @@ def test_modulemd_defaults_content(client, requests_mocker):
                 "metadata": {
                     "_content_type_id": "modulemd_defaults",
                     "name": "mdd",
-                    "stream": "1.0",
                     "repo_id": "some-repo",
                     "profiles": {"p1": ["something"]},
                 }


### PR DESCRIPTION
If you look at the schema defined in Pulp, 'stream' and 'profiles' are
not actually mandatory (not part of the unit key).

Although I believe in practice they're expected to be defined for all
real data, the fact that they're not part of the unit key means they're
omitted from responses in some contexts (e.g. units_succcessful in
associate/unassociate calls), therefore they must not be mandatory here
or crashes will occur when handling those responses.

Declaration of 'profiles' was also tweaked for consistency with other
fields: in other classes, a value which is allowed to be None still has
a type declared (as all types are understood to be nullable), so the
fact that this field can be None is not a reason to omit a type here
either.

One test was tweaked to ensure no crashes when stream is missing.

Relates to RHELDST-861.