### PR TITLE
Use default registry_id when it's not in distributor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Use repo id as registry_id when it's not set in distributor config or set to null or empty string
 
 ## [2.6.0] - 2020-05-05
 

--- a/pubtools/pulplib/_impl/model/repository/container.py
+++ b/pubtools/pulplib/_impl/model/repository/container.py
@@ -47,8 +47,9 @@ class ContainerImageRepository(Repository):
 
         for dist in data.get("distributors") or []:
             if dist["distributor_type_id"] == "docker_distributor_web":
-                if "repo-registry-id" in dist["config"]:
-                    out["registry_id"] = dist["config"].get("repo-registry-id")
+                registry_id = dist["config"].get("repo-registry-id")
+                if registry_id:
+                    out["registry_id"] = registry_id
                 break
 
         return out

--- a/pubtools/pulplib/_impl/model/repository/container.py
+++ b/pubtools/pulplib/_impl/model/repository/container.py
@@ -47,7 +47,8 @@ class ContainerImageRepository(Repository):
 
         for dist in data.get("distributors") or []:
             if dist["distributor_type_id"] == "docker_distributor_web":
-                out["registry_id"] = dist["config"].get("repo-registry-id")
+                if "repo-registry-id" in dist["config"]:
+                    out["registry_id"] = dist["config"].get("repo-registry-id")
                 break
 
         return out

--- a/tests/repository/test_container_image_repository.py
+++ b/tests/repository/test_container_image_repository.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pubtools.pulplib import Repository, ContainerImageRepository
 
 
@@ -32,9 +34,16 @@ def test_registry_id_from_distributor():
 
     assert repo.registry_id == "some/repo"
 
-
-def test_default_registry_id_from_distributor():
-    """default registry_id is used when it's not defined in distributor"""
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"repo-registry-id": ""},
+        {"repo-registry-id": None}
+    ],
+)
+def test_default_registry_id_from_distributor(config):
+    """default registry_id is used when it's not set in distributor or set to null/empty string"""
     repo = Repository.from_data(
         {
             "id": "my-repo",
@@ -43,7 +52,7 @@ def test_default_registry_id_from_distributor():
                 {
                     "id": "docker_web_distributor_name_cli",
                     "distributor_type_id": "docker_distributor_web",
-                    "config": {},
+                    "config": config,
                 }
             ],
         }

--- a/tests/repository/test_container_image_repository.py
+++ b/tests/repository/test_container_image_repository.py
@@ -34,13 +34,9 @@ def test_registry_id_from_distributor():
 
     assert repo.registry_id == "some/repo"
 
+
 @pytest.mark.parametrize(
-    "config",
-    [
-        {},
-        {"repo-registry-id": ""},
-        {"repo-registry-id": None}
-    ],
+    "config", [{}, {"repo-registry-id": ""}, {"repo-registry-id": None}]
 )
 def test_default_registry_id_from_distributor(config):
     """default registry_id is used when it's not set in distributor or set to null/empty string"""

--- a/tests/repository/test_container_image_repository.py
+++ b/tests/repository/test_container_image_repository.py
@@ -31,3 +31,22 @@ def test_registry_id_from_distributor():
     )
 
     assert repo.registry_id == "some/repo"
+
+
+def test_default_registry_id_from_distributor():
+    """default registry_id is used when it's not defined in distributor"""
+    repo = Repository.from_data(
+        {
+            "id": "my-repo",
+            "notes": {"_repo-type": "docker-repo"},
+            "distributors": [
+                {
+                    "id": "docker_web_distributor_name_cli",
+                    "distributor_type_id": "docker_distributor_web",
+                    "config": {},
+                }
+            ],
+        }
+    )
+
+    assert repo.registry_id == "my-repo"


### PR DESCRIPTION
For a repo which has docker_distributor_web distributor, and repo-registry-id is not set in the distributor's config, use repo id as its default registry_id.