### PR TITLE
Allow customizing throttle count for task executor

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -109,6 +109,9 @@ class Client(object):
 
                 These may be used, for example, to configure the credentials
                 for the Pulp server or to use an alternative CA bundle.
+
+            task_throttle
+                If passed in kwargs, it'll be used as param to _task_executor.
         """
         self._url = url
 
@@ -127,6 +130,8 @@ class Client(object):
         ):
             if arg in kwargs:
                 self._session_kwargs[arg] = kwargs.pop(arg)
+
+        _task_throttle = kwargs.pop("task_throttle", self._TASK_THROTTLE)
 
         if kwargs:
             raise TypeError(
@@ -158,7 +163,7 @@ class Client(object):
             .with_map(self._unpack_response)
             .with_map(self._log_spawned_tasks)
             .with_poll(poller, cancel_fn=poller.cancel)
-            .with_throttle(self._TASK_THROTTLE)
+            .with_throttle(_task_throttle)
             .with_retry(retry_policy=self._RETRY_POLICY)
         )
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -110,8 +110,10 @@ class Client(object):
                 These may be used, for example, to configure the credentials
                 for the Pulp server or to use an alternative CA bundle.
 
-            task_throttle
-                If passed in kwargs, it'll be used as param to _task_executor.
+            int task_throttle
+                Maximum number of queued or running tasks permitted for this client.
+                If more than this number of tasks are running, the client will wait before triggering more.
+                This can be used to ensure no single client overwhelms the Pulp server.
         """
         self._url = url
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -103,17 +103,17 @@ class Client(object):
             str url
                 URL of a Pulp server, e.g. https://pulp.example.com/.
 
+            int task_throttle
+                Maximum number of queued or running tasks permitted for this client.
+                If more than this number of tasks are running, the client will wait before triggering more.
+                This can be used to ensure no single client overwhelms the Pulp server.
+
             object auth, cert, headers, max_redirects, params, proxies, verify
                 Any of these arguments, if provided, are used to initialize
                 :class:`requests.Session` objects used by the client.
 
                 These may be used, for example, to configure the credentials
                 for the Pulp server or to use an alternative CA bundle.
-
-            int task_throttle
-                Maximum number of queued or running tasks permitted for this client.
-                If more than this number of tasks are running, the client will wait before triggering more.
-                This can be used to ensure no single client overwhelms the Pulp server.
         """
         self._url = url
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -25,6 +25,16 @@ def test_can_construct(requests_mocker):
     client = Client("https://pulp.example.com/")
 
 
+def test_can_construct_with_throttle_arg(requests_mocker):
+    """
+    A client instance can be constructed with task_throttle arg that is passed
+    to Client._task_executor
+    """
+    throttle_count = 42
+    client = Client("https://pulp.example.com/", task_throttle=throttle_count)
+    assert client._task_executor._throttle == throttle_count
+
+
 def test_can_construct_with_session_args(requests_mocker):
     """A client instance can be constructed with requests.Session kwargs."""
     client = Client("https://pulp.example.com/", auth=("x", "y"), verify=False)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -32,7 +32,7 @@ def test_can_construct_with_throttle_arg(requests_mocker):
     """
     throttle_count = 42
     client = Client("https://pulp.example.com/", task_throttle=throttle_count)
-    assert client._task_executor._throttle == throttle_count
+    assert client._task_executor._delegate._throttle() == throttle_count
 
 
 def test_can_construct_with_session_args(requests_mocker):


### PR DESCRIPTION
This change allows to customize count of throttle
for Client._task_executor by passing arg to Client.

In practice this will allow to run specific number of tasks
at one time.