### PR TITLE
Fix pylint and black issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -96,4 +96,7 @@ disable=print-statement,
         # we use black code style and don't need additional checks
         bad-continuation,
         line-too-long,
+        # skip linting Python 3 features
+        super-with-arguments,
+        raise-missing-from,
 

--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -2,7 +2,7 @@ import sys
 
 import attr
 
-ATTR_VERSION = tuple([int(x) for x in attr.__version__.split(".")[0:2]])
+ATTR_VERSION = tuple(int(x) for x in attr.__version__.split(".")[0:2])
 
 # pylint: disable=invalid-name
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ deps=
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black
-	pylint
+	black==20.8b1
+	pylint==2.7.2
 commands=
 	black --check .
 	sh -c 'pylint pubtools; test $(( $? & (1|2|4|32) )) = 0'


### PR DESCRIPTION
1) Pinned black and pylint to specific version in tox.ini
2) Add exceptions for pylint related to py3 features
3) Fixed unnecessary creation of list in compat_attr.py