### PR TITLE
YumRepository can retrieve related binary, debug or source repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for various repo notes for Repository model
 - Support for various fields of ModuleMd unit
-- Introduced YumRepository.related_*_repository properties that can retrive
+- Introduced YumRepository.related_x_repository properties that can retrieve
   related binary, debug and source repository
 
 ## [2.8.0] - 2021-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for various repo notes for Repository model
 - Support for various fields of ModuleMd unit
+- Introduced YumRepository.related_*_repository properties that can retrive
+  related binary, debug and source repository
 
 ## [2.8.0] - 2021-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for various repo notes for Repository model
 - Support for various fields of ModuleMd unit
-- Introduced YumRepository.related_x_repository properties that can retrieve
+- Introduced YumRepository.get_x_repository methods that can retrieve
   related binary, debug and source repository
 
 ## [2.8.0] - 2021-03-17

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -1,7 +1,13 @@
+import re
+
+from more_executors.futures import f_map, f_proxy
 from .base import Repository, SyncOptions, repo_type
 from ..frozenlist import FrozenList
 from ..attr import pulp_attrib
+from ..common import DetachedException
 from ... import compat_attr as attr
+from ...client.errors import PulpException
+from ...criteria import Criteria
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -95,3 +101,50 @@ class YumRepository(Repository):
         default=None, type=str, pulp_field="notes.ubi_config_version"
     )
     """Version of ubi config that should be used for population of this repository"""
+    @property
+    def related_binary_repository(self):
+        """Returns related binary repository to this repository based on relative url,
+        raises PulpException is repository is not found"""
+        return self._get_related_repository(repo_t="binary")
+
+    @property
+    def related_debug_repository(self):
+        """Returns related debug repository to this repository based on relative url
+        raises PulpException is repository is not found"""
+        return self._get_related_repository(repo_t="debug")
+
+    @property
+    def related_source_repository(self):
+        """Returns related source repository to this repository based on relative url
+        raises PulpException is repository is not found"""
+        return self._get_related_repository(repo_t="source")
+
+    def _get_related_repository(self, repo_t):
+        if not self._client:
+            raise DetachedException()
+
+        suffixes_mapping = {
+            "binary": "/os",
+            "debug": "/debug",
+            "source": "/source/SRPMS",
+        }
+
+        regex = r"(/os|/source/SRPMS|/debug)$"
+
+        def unpack_page(page):
+            if len(page.data) != 1:
+                raise PulpException(
+                    "Repository relative_url=%s was not found" % relative_url
+                )
+            return page.data[0]
+
+        suffix = suffixes_mapping[repo_t]
+        if str(self.relative_url).endswith(suffix):
+            return self
+
+        base_url = re.sub(regex, "", self.relative_url)
+        relative_url = base_url + suffix
+        criteria = Criteria.with_field("notes.relative_url", relative_url)
+        page_f = self._client.search_repository(criteria)
+        repo_f = f_map(page_f, unpack_page)
+        return f_proxy(repo_f)

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -6,7 +6,6 @@ from ..frozenlist import FrozenList
 from ..attr import pulp_attrib
 from ..common import DetachedException
 from ... import compat_attr as attr
-from ...client.errors import PulpException
 from ...criteria import Criteria
 
 
@@ -101,22 +100,20 @@ class YumRepository(Repository):
         default=None, type=str, pulp_field="notes.ubi_config_version"
     )
     """Version of ubi config that should be used for population of this repository"""
-    @property
-    def related_binary_repository(self):
+
+    def get_binary_repository(self):
         """Returns related binary repository to this repository based on relative url,
-        raises PulpException is repository is not found"""
+        or Future[None] if repository is not found"""
         return self._get_related_repository(repo_t="binary")
 
-    @property
-    def related_debug_repository(self):
+    def get_debug_repository(self):
         """Returns related debug repository to this repository based on relative url
-        raises PulpException is repository is not found"""
+        or Future[None] if repository is not found"""
         return self._get_related_repository(repo_t="debug")
 
-    @property
-    def related_source_repository(self):
+    def get_source_repository(self):
         """Returns related source repository to this repository based on relative url
-        raises PulpException is repository is not found"""
+        or Future[None] if repository is not found"""
         return self._get_related_repository(repo_t="source")
 
     def _get_related_repository(self, repo_t):
@@ -133,9 +130,8 @@ class YumRepository(Repository):
 
         def unpack_page(page):
             if len(page.data) != 1:
-                raise PulpException(
-                    "Repository relative_url=%s was not found" % relative_url
-                )
+                return None
+
             return page.data[0]
 
         suffix = suffixes_mapping[repo_t]

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -1,6 +1,6 @@
 import re
 
-from more_executors.futures import f_map, f_proxy
+from more_executors.futures import f_map, f_proxy, f_return
 from .base import Repository, SyncOptions, repo_type
 from ..frozenlist import FrozenList
 from ..attr import pulp_attrib
@@ -136,7 +136,7 @@ class YumRepository(Repository):
 
         suffix = suffixes_mapping[repo_t]
         if str(self.relative_url).endswith(suffix):
-            return self
+            return f_proxy(f_return(self))
 
         base_url = re.sub(regex, "", self.relative_url)
         relative_url = base_url + suffix

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -102,18 +102,18 @@ class YumRepository(Repository):
     """Version of ubi config that should be used for population of this repository"""
 
     def get_binary_repository(self):
-        """Returns related binary repository to this repository based on relative url,
-        or Future[None] if repository is not found"""
+        """Returns related binary repository to this repository based on relative url
+        or Future[None], if repository is not found"""
         return self._get_related_repository(repo_t="binary")
 
     def get_debug_repository(self):
         """Returns related debug repository to this repository based on relative url
-        or Future[None] if repository is not found"""
+        or Future[None], if repository is not found"""
         return self._get_related_repository(repo_t="debug")
 
     def get_source_repository(self):
         """Returns related source repository to this repository based on relative url
-        or Future[None] if repository is not found"""
+        or Future[None], if repository is not found"""
         return self._get_related_repository(repo_t="source")
 
     def _get_related_repository(self, repo_t):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.9.0",
+    version="2.10.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/repository/test_yum_repository.py
+++ b/tests/repository/test_yum_repository.py
@@ -83,7 +83,7 @@ def test_populate_attrs():
 def test_related_repositories(client, requests_mocker):
     """test Repository.get_*_repository returns expected objects"""
 
-    repo_binary_test = YumRepository(id="binary-repo", relative_url="some/repo/os")
+    repo_binary_test = YumRepository(id="repo_binary", relative_url="some/repo/os")
     repo_binary_test.__dict__["_client"] = client
 
     requests_mocker.post(
@@ -92,7 +92,8 @@ def test_related_repositories(client, requests_mocker):
     )
 
     # Request for binary repo should return identical object
-    assert repo_binary_test is repo_binary_test.get_binary_repository()
+    assert repo_binary_test is repo_binary_test.get_binary_repository().result()
+    assert repo_binary_test.get_binary_repository().id == "repo_binary"
     # Requests for debug and source repositories return correct repositories
     assert repo_binary_test.get_debug_repository().id == "repo_debug"
     assert repo_binary_test.get_source_repository().id == "repo_source"
@@ -101,7 +102,7 @@ def test_related_repositories(client, requests_mocker):
 def test_related_repositories_not_found(client, requests_mocker):
     """test Repository.get_*_repository returns Future[None] if repository is not found"""
 
-    repo_binary_test = YumRepository(id="binary-repo", relative_url="some/repo/os")
+    repo_binary_test = YumRepository(id="repo_binary", relative_url="some/repo/os")
     repo_binary_test.__dict__["_client"] = client
 
     requests_mocker.post(
@@ -113,7 +114,7 @@ def test_related_repositories_not_found(client, requests_mocker):
 
 
 def test_related_repositories_detached_client():
-    repo_binary_test = YumRepository(id="binary-repo", relative_url="some/repo/os")
+    repo_binary_test = YumRepository(id="repo_binary", relative_url="some/repo/os")
     repo_binary_test.__dict__["_client"] = None
 
     with pytest.raises(DetachedException):


### PR DESCRIPTION
Added methods to YumRepository that can retrieve
related binary, debug or source repository.
The search is based on relative urls and the expected suffixes
of different yum repositories.