### PR TITLE
Add pulp_repository_published hook using new hooks system

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -100,3 +100,7 @@ disable=print-statement,
         super-with-arguments,
         raise-missing-from,
 
+[TYPECHECK]
+ignored-classes=
+    # dynamic pluggy stuff
+    _HookRelay,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### n/a
+### Added
+
+- Introduced `pulp_repository_published` hook. This may be used to subscribe to all
+  repository publish events triggered by this library.
 
 ## [2.10.0] - 2021-06-28
 

--- a/pubtools/pulplib/_impl/hooks.py
+++ b/pubtools/pulplib/_impl/hooks.py
@@ -1,0 +1,20 @@
+import sys
+
+from pubtools.pluggy import hookspec, pm
+
+
+# pylint: disable=unused-argument
+
+
+@hookspec
+def pulp_repository_published(repository, options):
+    """Invoked after a Pulp repository has been successfully published.
+
+    :param repository: the repository which has been published.
+    :type repository: pubtools.pulplib.Repository
+    :param options: the options used for this publish.
+    :type options: pubtools.pulplib.PublishOptions
+    """
+
+
+pm.add_hookspecs(sys.modules[__name__])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ six
 PyYAML
 jsonschema
 attrs
+pubtools>=0.3.0


### PR DESCRIPTION
pubtools recently introduced a hooks/event system. Let's define
a hook invoked after repos are published, for reasons:

- it's a natural way to handle the requirement of "CDN cache should
  be flushed after repo is published"

- as a simple and low-risk first hook to try out the new system.