### PR TITLE
Bump more-executors dep to fix serialization issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-more-executors>=2.7.0
+more-executors>=2.8.1
 six
 PyYAML
 jsonschema


### PR DESCRIPTION
Earlier versions of the library had a bug on python2 which could
cause unexpected serialization of futures if mixing f_proxy and
f_map, as done within pubtools-pulplib; see RHELDST-7232 for an
example of the effect.

No code changes in pubtools-pulplib are needed to fix this.
Just bump the dependency to ensure all environments are avoiding that
bug.