### PR TITLE
Make Client support context manager protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- `Client` instances can now be used in a `with` statement to manage the lifecycle
+  of the underlying threads.
 
 ## [2.11.0] - 2021-07-15
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ Usage Example
 from pubtools.pulplib import Client
 
 # Make a client pointing at this Pulp server
-client = Client(url='https://pulp.example.com/', auth=('admin', 'some-password'))
+with Client(url='https://pulp.example.com/', auth=('admin', 'some-password')) as client:
 
-# Get a particular repo by ID.
-# All methods return Future instances; .result() blocks
-repo = client.get_repository('zoo').result()
+  # Get a particular repo by ID.
+  # All methods return Future instances; .result() blocks
+  repo = client.get_repository('zoo').result()
 
-# Pulp objects have relevant methods, e.g. publish().
-# Returned future may encapsulate one or more Pulp tasks.
-publish = repo.publish().result()
+  # Pulp objects have relevant methods, e.g. publish().
+  # Returned future may encapsulate one or more Pulp tasks.
+  publish = repo.publish().result()
 ```
 
 Development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,12 +28,12 @@ the desired methods to perform actions on Pulp.
     from pubtools.pulplib import Client
 
     # Make a client pointing at this Pulp server
-    client = Client(url='https://pulp.example.com/', auth=('admin', 'some-password'))
+    with Client(url='https://pulp.example.com/', auth=('admin', 'some-password')) as client:
 
-    # Get a particular repo by ID.
-    # All methods return Future instances; .result() blocks
-    repo = client.get_repository('zoo').result()
+        # Get a particular repo by ID.
+        # All methods return Future instances; .result() blocks
+        repo = client.get_repository('zoo').result()
 
-    # Pulp objects have relevant methods, e.g. publish().
-    # Returned future may encapsulate one or more Pulp tasks.
-    publish = repo.publish().result()
+        # Pulp objects have relevant methods, e.g. publish().
+        # Returned future may encapsulate one or more Pulp tasks.
+        publish = repo.publish().result()

--- a/examples/upload-files
+++ b/examples/upload-files
@@ -73,8 +73,8 @@ def main():
         logging.getLogger("pubtools.pulplib").setLevel(logging.DEBUG)
         log.setLevel(logging.DEBUG)
 
-    client = make_client(p)
-    return upload(client, p.path, p.repo_id)
+    with make_client(p) as client:
+        return upload(client, p.path, p.repo_id)
 
 
 if __name__ == "__main__":

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -41,6 +41,21 @@ class Client(object):
     If a future is currently awaiting one or more Pulp tasks, cancelling the future
     will attempt to cancel those tasks.
 
+    **Client lifecycle:**
+
+    .. versionadded:: 2.12.0
+
+    Client instances support the context manager protocol and can be used
+    via a ``with`` statement, as in example:
+
+    .. code-block:: python
+
+        with Client(url="https://pulp.example.com/") as client:
+            do_something_with(client)
+
+    While not mandatory, it is encouraged to ensure that any threads associated with
+    the client are promptly shut down.
+
     **Proxy futures:**
 
     .. versionadded:: 2.1.0
@@ -172,6 +187,13 @@ class Client(object):
             .with_throttle(_task_throttle)
             .with_retry(retry_policy=self._RETRY_POLICY)
         )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._request_executor.__exit__(*args, **kwargs)
+        self._task_executor.__exit__(*args, **kwargs)
 
     def get_repository(self, repository_id):
         """Get a repository by ID.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.11.0",
+    version="2.12.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",


### PR DESCRIPTION
Clients use thread-based executors under the hood, but we did not
provide any mechanism to shut them down. This is bad design as it means
there's no reliable way to limit the number of spawned threads if you
need to create many clients (e.g. while running a test suite where
new clients are being created in each test).

Make it work in a 'with' statement so it's possible to shut down all
threads associated with the client; attempting to use a client after
shutdown will raise an error. It's not mandatory, but usage of 'with'
is recommended, so several examples and docs were updated to do that.

FakeClient doesn't use any threads but is intended to have as close as
possible behavior to a real Client, so it also raises the same errors
if used after shutdown.

This is similar in spirit to
https://github.com/release-engineering/pushsource/commit/1ebda2c31657d86c68b14c9ea57475976d3e4a07.