### PR TITLE
Bugfix - fix handling of type_ids in remove_content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# JetBrains
+.idea/

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -1,15 +1,15 @@
-import os
-import logging
-import threading
 import hashlib
 import json
+import logging
+import os
+import threading
 from functools import partial
-import six
-from six.moves import StringIO
 
 import requests
+import six
 from more_executors import Executors
 from more_executors.futures import f_map, f_flat_map, f_return, f_proxy, f_sequence
+from six.moves import StringIO
 
 from ..page import Page
 from ..criteria import Criteria
@@ -17,6 +17,10 @@ from ..model import Repository, MaintenanceReport, Distributor, Unit
 from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
+from .search import search_for_criteria
+from ..criteria import Criteria
+from ..model import Repository, MaintenanceReport, Distributor, Unit
+from ..page import Page
 from . import retry
 
 
@@ -470,14 +474,21 @@ class Client(object):
             self._do_request, method="POST", url=url, json=body
         )
 
-    def _do_unassociate(self, repo_id, type_ids):
+    def _do_unassociate(self, repo_id, criteria=None):
         url = os.path.join(
             self._url, "pulp/api/v2/repositories/%s/actions/unassociate/" % repo_id
         )
 
-        body = {}
-        if type_ids is not None:
-            body["type_ids"] = type_ids
+        # use type hint=Unit so that if type_ids are the goal here
+        # then we will get back a properly prepared PulpSearch with
+        # a populated type_ids field
+        pulp_search = search_for_criteria(criteria, type_hint=Unit, type_ids_accum=None)
+
+        body = {
+            "criteria": {
+                "type_ids": pulp_search.type_ids,
+            }
+        }
 
         LOG.debug("Submitting %s unassociate: %s", url, body)
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -17,10 +17,6 @@ from ..model import Repository, MaintenanceReport, Distributor, Unit
 from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
-from .search import search_for_criteria
-from ..criteria import Criteria
-from ..model import Repository, MaintenanceReport, Distributor, Unit
-from ..page import Page
 from . import retry
 
 
@@ -484,11 +480,7 @@ class Client(object):
         # a populated type_ids field
         pulp_search = search_for_criteria(criteria, type_hint=Unit, type_ids_accum=None)
 
-        body = {
-            "criteria": {
-                "type_ids": pulp_search.type_ids,
-            }
-        }
+        body = {"criteria": {"type_ids": pulp_search.type_ids}}
 
         LOG.debug("Submitting %s unassociate: %s", url, body)
 

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -277,7 +277,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         return out
 
-    def _do_unassociate(self, repo_id, type_ids):
+    def _do_unassociate(self, repo_id, criteria=None):
         repo_f = self.get_repository(repo_id)
         if repo_f.exception():
             return repo_f
@@ -286,8 +286,16 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         removed = set()
         kept = set()
 
+        # use type hint=Unit so that if type_ids are the goal here
+        # then we will get back a properly prepared PulpSearch with
+        # a populated type_ids field
+        pulp_search = search_for_criteria(criteria, type_hint=Unit, type_ids_accum=None)
+
         for unit in current:
-            if type_ids is None or unit.content_type_id in type_ids:
+            if (
+                pulp_search.type_ids is None
+                or unit.content_type_id in pulp_search.type_ids
+            ):
                 removed.add(unit)
             else:
                 kept.add(unit)

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -481,7 +481,7 @@ class Repository(PulpObject, Deletable):
         # (more generically named) functions or a class to avoid duplicating code.
         # for reference see search_content, _impl.client.Client._search_repo_units,
         # _impl.client.Client._search, and _impl.client.search.search_for_criteria
-        criteria = kwargs.get("criteria", None)
+        criteria = kwargs.get("criteria")
 
         # prefer criteria keyword argument
         # if absent, check for original type_ids keyword arg

--- a/tests/repository/test_remove_content.py
+++ b/tests/repository/test_remove_content.py
@@ -77,7 +77,7 @@ def test_remove_with_type_ids(fast_poller, requests_mocker, client):
         req[0].url
         == "https://pulp.example.com/pulp/api/v2/repositories/some-repo/actions/unassociate/"
     )
-    assert req[0].json() == {"type_ids": ["type1", "type2"]}
+    assert req[0].json() == {"criteria": {"type_ids": ["type1", "type2"]}}
 
 
 def test_remove_loads_units(fast_poller, requests_mocker, client):


### PR DESCRIPTION
Overview
=======
Fix a bug in `Repository#remove_content` causing all content to be removed from a repository, even when one or more content type IDs are passed to it.

From [the Pulp 2.x docs][pulp_docs_unit_association], the body of an `unassociate` request should be a `criteria` object of which `type_ids` is a field.

The current implementation adds

```json
{"type_ids": [...]}
```

to the request body, when it should be

```json
{"criteria": {"type_ids": [...]}}
```

This is also consistent with other parts of the codebase e.g. the [Search API][client_search], which correctly adds the `type_ids` field to a parent `criteria` object.

Approach
-------------
Rather than working with raw `dict`s and hard-coded string keys, my initial approach was to model the criteria object with a new data class called `CriteriaDocument` that encapsulates necessary fields, and knows how to serialize itself to JSON for the request body.

Eventually I noticed that the search API uses existing `Criteria` and `Matcher` classes, as well as some helper functions to do the same thing. In fact, there is an [open issue][github_pulplib_issue] that asks to extend `Repository#remove_content` to accept and handle `Criteria`. After seeing this, it made sense to try and use existing APIs to fix this bug and start moving in that direction.

Unfortunately, there seems to be some complex handling of `Criteria` in the search API in order to properly serialize them for client requests due to the need to incorporate MongoDB query syntax. It is unclear how much of that extra handling of `Criteria` is necessary to properly extend `remove_content` to accept `Criteria`. If most or all of the same handling is needed, then it would be beneficial to extract the business logic to a couple classes, or to possibly rename some existing helper functions (current helpers are named specifically for the search API) to avoid duplicating code and/or sewing confusion (e.g. `remove_content` using a function called `search_for_criteria` is a bit confusing).

The updated implementation here prefers a `Criteria` object passed in using the `criteria` kwarg, but falls back to the old `type_ids` kwarg if no `Criteria` is present. Some changes to both `Client` and `FakeClient` were made to work with a `Criteria` instance rather than a list of content type IDs. `test_remove_content.py` needed to be updated to reflect the correct expected value of the `unassociate` request body.

[repository_remove_content]: pubtools/pulplib/_impl/model/base.py#L441
[pulp_docs_unit_association]: https://docs.pulpproject.org/en/2.12/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
[client_search]: https://github.com/release-engineering/pubtools-pulplib/blob/master/pubtools/pulplib/_impl/client/client.py#L328
[github_pulplib_issue]: https://github.com/release-engineering/pubtools-pulplib/issues/62