### PR TITLE
ci: fix pidiff since introduction of pubtools dep

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands=
 [testenv:pidiff]
 deps=pidiff
 skip_install=true
-commands=pidiff pubtools-pulplib .
+commands=pidiff pubtools-pulplib . pubtools.pulplib {posargs}
 
 [testenv:cov]
 deps=


### PR DESCRIPTION
A dependency of (pubtools-pulplib => pubtools) was recently
introduced.

This appears to break pidiff's handling of this library. Previously, in
a venv with pubtools-pulplib installed, "pubtools" would be the root
module for pubtools-pulplib code (only).  Now it is the root namespace
sharing code for both "pubtools-pulplib" and "pubtools", and pidiff
can't automatically tell the difference.

It can be fixed by explicitly telling the tool which module should be
checked.

{posargs} were also added so that one can run e.g.
"tox -e pidiff -- -vv" for debugging purposes.