### PR TITLE
Added vercmp sorting for RpmUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 install: pip install tox
 matrix:
   include:
-  - python: "2.7"
+  - python: "2.7.15"
     env: TOX_ENV=py27
   - python: "3.6"
     env: TOX_ENV=static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- vercmp sort for RpmUnit
 
 ## [2.12.1] - 2021-08-11
 

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -4,6 +4,7 @@ from ..attr import pulp_attrib
 from ... import compat_attr as attr
 from ..frozenlist import frozenlist_or_none_converter
 
+from rpm import labelCompare as label_compare  # pylint: disable=no-name-in-module
 
 # Note: Pulp2 models RPM and SRPM as separate unit types,
 # but there's actually no difference between their fields at all.
@@ -119,3 +120,25 @@ class RpmUnit(Unit):
     @sha256sum.validator
     def _check_sha256(self, _, value):
         self._check_sum(value, "SHA256", 64)
+
+    @property
+    def _evr_tuple(self):
+        return (self.epoch, self.version, self.release)
+
+    def __lt__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) < 0
+
+    def __gt__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) > 0
+
+    def __eq__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) == 0
+
+    def __le__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) <= 0
+
+    def __ge__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) >= 0
+
+    def __ne__(self, other):
+        return label_compare(self._evr_tuple, other._evr_tuple) != 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML
 jsonschema
 attrs
 pubtools>=0.3.0
+rpm-py-installer

--- a/tests/unit/test_rpm_sort.py
+++ b/tests/unit/test_rpm_sort.py
@@ -1,0 +1,88 @@
+from pubtools.pulplib import RpmUnit
+
+
+def test_rpm_sort_epoch():
+    """Tests vercmp sort with different epochs."""
+    rpm_1 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="1",
+        name="glibc-headers",
+        release="2.57.el4.1",
+        repository_memberships=["fake-repository-id-3"],
+        sourcerpm="glibc-2.3.4-2.57.el4.1.src.rpm",
+        version="2.3.4",
+    )
+
+    rpm_2 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="0",
+        name="glibc-headers",
+        release="2.57.el4.1",
+        repository_memberships=["fake-repository-id-3"],
+        sourcerpm="glibc-2.3.4-2.57.el4.1.src.rpm",
+        version="2.3.4",
+    )
+
+    rpms = [rpm_1, rpm_2]
+
+    sorted_rpms = sorted(rpms)
+
+    assert sorted_rpms == [rpm_2, rpm_1]
+
+
+def test_rpm_sort_release():
+    """Tests vercmp sort with different releases."""
+
+    rpm_1 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="0",
+        name="glibc-headers",
+        release="2.57.el4.1",
+        version="2.3.4",
+    )
+
+    rpm_2 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="0",
+        name="glibc-headers",
+        release="2.56.el4.1",
+        version="2.3.4",
+    )
+
+    rpms = [rpm_1, rpm_2]
+
+    sorted_rpms = sorted(rpms)
+
+    assert sorted_rpms == [rpm_2, rpm_1]
+
+
+def test_rpm_sort_version():
+    """Tests vercmp sort with different versions."""
+
+    rpm_1 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="0",
+        name="glibc-headers",
+        release="2.57.el4.1",
+        version="2.3.5",
+    )
+
+    rpm_2 = RpmUnit(
+        sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
+        arch="ia64",
+        epoch="0",
+        name="glibc-headers",
+        release="2.57.el4.1",
+        version="2.3.4",
+    )
+
+    rpms = [rpm_1, rpm_2]
+
+    sorted_rpms = sorted(rpms)
+
+    assert sorted_rpms == [rpm_2, rpm_1]


### PR DESCRIPTION
Objects of RpmUnit class are now sortable and comparable by standard
vercmp algorithm using epoch, version and release of the unit.
The sorting doesn't take name or arch into account.