### PR TITLE
Ensure repository_membership is set by search_content

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -266,7 +266,10 @@ class Client(object):
             )
 
         return self._search(
-            Unit, ["content/units/%s" % x for x in type_ids], criteria=criteria
+            Unit,
+            ["content/units/%s" % x for x in type_ids],
+            criteria=criteria,
+            search_options={"include_repos": True},
         )
 
     def search_distributor(self, criteria=None):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -501,6 +501,13 @@ def test_can_search_content(client, requests_mocker):
     # 3 requests, 1 for server type_ids, 1 for rpm, 1 for srpm
     assert requests_mocker.call_count == 3
 
+    # Request body should look like this: limit is always applied,
+    # repos are always requested
+    assert requests_mocker.request_history[-1].json() == {
+        "criteria": {"skip": 0, "limit": 2000, "filters": {}},
+        "include_repos": True,
+    }
+
 
 def test_can_search_content_invalid_criteria(client, requests_mocker):
     """search_content issues /search/ POST requests as expected."""


### PR DESCRIPTION
Units have a repository_memberships field, but it never ends up
populated if we don't set include_repos during our search request.
Let's start populating it.

It can be argued that this was a bug, because the fake client already did
return repository_memberships in units, so this looks like an
unintentional behavior difference between real and fake clients.

Needed for push workflow in RHELDST-5435.