### PR TITLE
Enforce a stable order on repository_memberships

### DIFF
--- a/pubtools/pulplib/_impl/model/frozenlist.py
+++ b/pubtools/pulplib/_impl/model/frozenlist.py
@@ -1,3 +1,6 @@
+import functools
+
+
 class FrozenList(list):
     # An immutable list subclass, intended for use on model fields.
 
@@ -35,7 +38,12 @@ class FrozenList(list):
         return hash(tuple(self))
 
 
-def frozenlist_or_none_converter(obj):
+def frozenlist_or_none_converter(obj, map_fn=(lambda x: x)):
     if obj is not None:
-        return FrozenList(obj)
+        return FrozenList(map_fn(obj))
     return None
+
+
+frozenlist_or_none_sorted_converter = functools.partial(
+    frozenlist_or_none_converter, map_fn=sorted
+)

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -2,7 +2,7 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..frozenlist import frozenlist_or_none_converter
+from ..frozenlist import frozenlist_or_none_sorted_converter
 
 
 @unit_type("iso")
@@ -35,7 +35,7 @@ class FileUnit(Unit):
     repository_memberships = pulp_attrib(
         default=None,
         type=list,
-        converter=frozenlist_or_none_converter,
+        converter=frozenlist_or_none_sorted_converter,
         pulp_field="repository_memberships",
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -4,7 +4,10 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..frozenlist import frozenlist_or_none_converter
+from ..frozenlist import (
+    frozenlist_or_none_converter,
+    frozenlist_or_none_sorted_converter,
+)
 
 
 @unit_type("modulemd")
@@ -57,7 +60,7 @@ class ModulemdUnit(Unit):
     repository_memberships = pulp_attrib(
         default=None,
         type=list,
-        converter=frozenlist_or_none_converter,
+        converter=frozenlist_or_none_sorted_converter,
         pulp_field="repository_memberships",
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.

--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -2,7 +2,7 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..frozenlist import frozenlist_or_none_converter
+from ..frozenlist import frozenlist_or_none_sorted_converter
 
 
 @unit_type("modulemd_defaults")
@@ -28,7 +28,7 @@ class ModulemdDefaultsUnit(Unit):
     repository_memberships = pulp_attrib(
         default=None,
         type=list,
-        converter=frozenlist_or_none_converter,
+        converter=frozenlist_or_none_sorted_converter,
         pulp_field="repository_memberships",
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -2,7 +2,7 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..frozenlist import frozenlist_or_none_converter
+from ..frozenlist import frozenlist_or_none_sorted_converter
 
 
 # Note: Pulp2 models RPM and SRPM as separate unit types,
@@ -100,7 +100,7 @@ class RpmUnit(Unit):
     repository_memberships = pulp_attrib(
         default=None,
         type=list,
-        converter=frozenlist_or_none_converter,
+        converter=frozenlist_or_none_sorted_converter,
         pulp_field="repository_memberships",
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -15,6 +15,24 @@ def test_invariants(model_object):
     assert_model_invariants(model_object)
 
 
+@pytest.mark.parametrize("field_name", ["repository_memberships"])
+def test_stable_order(model_object, field_name):
+    """Test that certain fields on the given object have a stable ordering applied."""
+
+    if not hasattr(model_object, field_name):
+        pytest.skip("This object does not have %s" % field_name)
+
+    updates1 = {field_name: ["c", "a", "b"]}
+    updates2 = {field_name: ["a", "c", "b"]}
+
+    # Request two different updates on the object.
+    obj1 = attr.evolve(model_object, **updates1)
+    obj2 = attr.evolve(model_object, **updates2)
+
+    # The result should be exactly the same in both cases.
+    assert getattr(obj1, field_name) == getattr(obj2, field_name)
+
+
 def public_model_objects():
     """Returns a default-constructed instance of every public model class
     found in pubtools.pulplib.


### PR DESCRIPTION
These unit objects are meant to be a canonical representation of a
unit's current state which can be hashed, compared with ==, etc.

This is undermined somewhat if repository_memberships has no ordering
applied: the Pulp server can theoretically return this list in a
different order for multiple searches on the same unit.

Let's make the field sorted automatically on construction so that we get
more stable behavior in all cases.