### PR TITLE
Introduce Criteria.with_unit_type

### DIFF
--- a/pubtools/pulplib/_impl/client/search.py
+++ b/pubtools/pulplib/_impl/client/search.py
@@ -92,7 +92,7 @@ class TypeIdAccumulator(object):
             raise ValueError(
                 (
                     "Can't serialize criteria for Pulp query; too complicated. "
-                    "Try simplifying the query with respect to content_type_id."
+                    "Try simplifying the query with respect to unit_type/content_type_id."
                 )
             )
 

--- a/pubtools/pulplib/_impl/model/unit/__init__.py
+++ b/pubtools/pulplib/_impl/model/unit/__init__.py
@@ -1,4 +1,4 @@
-from .base import Unit
+from .base import Unit, type_ids_for_class
 from .file import FileUnit
 from .rpm import RpmUnit
 from .modulemd import ModulemdUnit

--- a/pubtools/pulplib/_impl/model/unit/base.py
+++ b/pubtools/pulplib/_impl/model/unit/base.py
@@ -19,6 +19,18 @@ def unit_type(pulp_type):
     return decorate
 
 
+def type_ids_for_class(unit_class):
+    # Given a concrete Unit subclass, returns those Pulp type id(s)
+    # which may be used to find/load an object of that class.
+    out = []
+
+    for pulp_type, klass in UNIT_CLASSES.items():
+        if klass is unit_class:
+            out.append(pulp_type)
+
+    return sorted(out)
+
+
 @attr.s(kw_only=True, frozen=True)
 class Unit(PulpObject):
     """Represents a Pulp unit (a single piece of content).

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.13.0",
+    version="2.14.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/criteria/test_criteria.py
+++ b/tests/criteria/test_criteria.py
@@ -13,3 +13,10 @@ def test_field_in_str_invalid():
     with pytest.raises(ValueError) as exc_info:
         Criteria.with_field_in("x", "someval")
     assert "Must be an iterable: 'someval'" in str(exc_info.value)
+
+
+def test_unit_type_invalid():
+    """Criteria.with_unit_type raises if provided value isn't a unit subclass."""
+    with pytest.raises(TypeError) as exc_info:
+        Criteria.with_unit_type([1, 2, 3])
+    assert "Expected a Unit type, got: [1, 2, 3]" in str(exc_info.value)

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -120,6 +120,21 @@ def test_search_content_by_unit_field(populated_repo):
     ]
 
 
+def test_search_content_by_unit_type(populated_repo):
+    """search_content on unit_type returns only units of that type"""
+
+    crit = Criteria.with_unit_type(ModulemdUnit)
+    units = list(populated_repo.search_content(crit))
+    assert sorted(units) == [
+        ModulemdUnit(
+            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+        ),
+        ModulemdUnit(
+            name="module2", stream="s2", version=1234, context="a1b2", arch="x86_64"
+        ),
+    ]
+
+
 def test_search_content_mixed_fields(populated_repo):
     """search_content crossing multiple fields and types returns matching units"""
 


### PR DESCRIPTION
It was already possible for callers to search for units of a specific
type by doing, for example:

    Criteria.with_field("content_type_id", Matcher.in_(["rpm", "srpm"]))

The problem with this is that it requires the caller to know which
values of content_type_id map to each model class such as RpmUnit.
The library already knows this implementation detail internally and it's
best to avoid duplicating it also in the user of the library.

This commit adds a helper which accepts Unit classes as input, as in:

    Criteria.with_unit_type(RpmUnit)

This allows the mapping between unit subclasses and content types to
remain fully encapsulated within this library.