### PR TITLE
ci: bump default py3 version to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ matrix:
   include:
   - python: "2.7"
     env: TOX_ENV=py27
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=static
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=pidiff
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=cov-travis DEPLOY=1
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=docs
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=revdep-pubtools-pulp
 script: tox -e $TOX_ENV
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,static,pidiff,docs,revdep-pubtools-pulp
+envlist = py27,py38,static,pidiff,docs,revdep-pubtools-pulp
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
The primary motivation is to get newer versions of testing tools which
are not available for 3.6. It's also consistent with the github actions
workflows in this repo (which is currently in progress of migrating from
travis to actions).