### PR TITLE
Refactor/fix handling of upload_file in fake client

### DIFF
--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -20,6 +20,7 @@ from pubtools.pulplib import (
     Repository,
     Distributor,
     Unit,
+    FileUnit,
     MaintenanceReport,
 )
 from pubtools.pulplib._impl.client.search import search_for_criteria
@@ -328,6 +329,23 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             return repo_f
 
         repo = repo_f.result()
+
+        # This code was originally written for generic file upload ("iso" units).
+        # It's certain that it will require refactoring for other types of units
+        # because we don't have enough metadata to create proper Unit instances
+        # for anything else. We can't get here for any other unit_type_id right now
+        # anyway, but as soon as we do make sure we fail in a controlled manner.
+        assert unit_type_id == "iso"
+
+        repo_units = self._repo_units.setdefault(repo_id, set())
+        repo_units.add(
+            FileUnit(
+                path=unit_key["name"],
+                size=unit_key["size"],
+                sha256sum=unit_key["checksum"],
+                repository_memberships=[repo_id],
+            )
+        )
 
         task = Task(id=self._next_task_id(), completed=True, succeeded=True)
 

--- a/pubtools/pulplib/_impl/fake/controller.py
+++ b/pubtools/pulplib/_impl/fake/controller.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .client import FakeClient
 
 
@@ -133,19 +135,26 @@ class FakeController(object):
 
     @property
     def upload_history(self):
-        """A list of upload tasks triggered via this client.
+        # A list of upload tasks triggered via this client.
+        #
+        # Each element of this list is a named tuple with the following attributes,
+        # in order:
+        #
+        #     ``repository``:
+        #         :class:`~pubtools.pulplib.Repository` for which upload was triggered
+        #     ``tasks``:
+        #         list of :class:`~pubtools.pulplib.Task` generated as a result
+        #         of this upload
+        #     ``name`` (str):
+        #         the remote path used
+        #     ``sha256`` (str):
+        #         checksum of the file uploaded
+        #
+        # Deprecated: structure was unintentionally specific to ISO units and is also
+        # unnecessary as uploading will make unit(s) available in the relevant repo.
+        #
+        warnings.warn(
+            "upload_history is deprecated, check repo units instead", DeprecationWarning
+        )
 
-        Each element of this list is a named tuple with the following attributes,
-        in order:
-
-            ``repository``:
-                :class:`~pubtools.pulplib.Repository` for which upload was triggered
-            ``tasks``:
-                list of :class:`~pubtools.pulplib.Task` generated as a result
-                of this upload
-            ``name`` (str):
-                the remote path used
-            ``sha256`` (str):
-                checksum of the file uploaded
-        """
         return self.client._upload_history[:]


### PR DESCRIPTION
"iso" units (generic files) are the first, and currently only, type of
content which can be uploaded by this library. There were two issues
with how this was handled on the fake client:

1. uploads were exposed via an `upload_history` property, whose name
   gives the impression of being generic and supporting all kinds of
   uploads, but whose implementation is arguably specific to "iso" units
   as it relies on fields specific to that unit type.

2. uploads were *only* exposed via that property, and would not show up
   in subsequent content searches. This goes against the intent of the
   fake client to behave in a realistic manner (at least with respect to
   CRUD operations). If the fake client is used to upload content into a
   repo, and then search for content within the repo, it should be able
   to find whatever was just uploaded.

Fix (2) so that the primary side-effect of an upload (make unit(s) exist
in a repo) is upheld for the fake client. With that behavior in place,
"fix" (1) by deprecating it as there's no clear reason why we'd need
this separate property if uploaded units can be queried normally.

Motivation: for RHELDST-5435 I need to start adding support for other
content types, but these problems ought to be fixed first.