### PR TITLE
README: update badges/links for migration to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ pubtools-pulplib
 A Python client for [Pulp 2.x](https://pulpproject.org/), used by
 [release-engineering](https://github.com/release-engineering) publishing tools.
 
-[![Build Status](https://travis-ci.org/release-engineering/pubtools-pulplib.svg?branch=master)](https://travis-ci.org/release-engineering/pubtools-pulplib)
-[![Coverage Status](https://coveralls.io/repos/github/release-engineering/pubtools-pulplib/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pubtools-pulplib?branch=master)
+[![Build Status](https://github.com/release-engineering/pubtools-pulplib/actions/workflows/tox-test.yml/badge.svg)](https://github.com/release-engineering/pubtools-pulplib/actions/workflows/tox-test.yml)
+[![codecov](https://codecov.io/gh/release-engineering/pubtools-pulplib/branch/master/graph/badge.svg?token=CABMY3WeIB)](https://codecov.io/gh/release-engineering/pubtools-pulplib)
 
 - [Source](https://github.com/release-engineering/pubtools-pulplib)
 - [Documentation](https://release-engineering.github.io/pubtools-pulplib/)


### PR DESCRIPTION
Refresh these according to recent changes:

- travis => github actions
- coveralls => codecov