### PR TITLE
Minor fixes for upload_file

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -439,7 +439,7 @@ class Client(object):
         # We only support returning the ID at this time.
         return f_proxy(f_map(out, lambda types: sorted([t["id"] for t in types])))
 
-    def _do_upload_file(self, upload_id, file_obj, name):
+    def _do_upload_file(self, upload_id, file_obj):
         def do_next_upload(checksum, size):
             data = file_obj.read(self._CHUNK_SIZE)
             if data:
@@ -458,11 +458,10 @@ class Client(object):
         if not is_file_object:
             file_obj = open(file_obj, "rb")
 
-        LOG.info("Uploading %s to Pulp", name)
         upload_f = f_flat_map(f_return(), lambda _: do_next_upload(hashlib.sha256(), 0))
 
-        if not is_file_object:
-            upload_f.add_done_callback(lambda _: file_obj.close())
+        upload_f.add_done_callback(lambda _: file_obj.close())
+
         return upload_f
 
     def _publish_repository(self, repo, distributors_with_config):

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -255,7 +255,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         return f_proxy(f_return(self._type_ids))
 
-    def _do_upload_file(self, upload_id, file_obj, name):
+    def _do_upload_file(self, upload_id, file_obj):
         # pylint: disable=unused-argument
         is_file_obj = "close" in dir(file_obj)
         if not is_file_obj:
@@ -273,8 +273,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         out = f_flat_map(f_return(), lambda _: do_next_upload(hashlib.sha256(), 0))
 
-        if not is_file_obj:
-            out.add_done_callback(lambda _: file_obj.close())
+        out.add_done_callback(lambda _: file_obj.close())
 
         return out
 

--- a/tests/fake/test_fake_upload_file.py
+++ b/tests/fake/test_fake_upload_file.py
@@ -104,7 +104,7 @@ def test_upload_nonexistent_file_raises():
     else:
         exception = FileNotFoundError
     with pytest.raises(exception):
-        upload_f = repo1.upload_file("nonexistent_file")
+        upload_f = repo1.upload_file("nonexistent_file").result()
 
 
 def test_upload_repo_absent_raises(tmpdir):

--- a/tests/repository/test_upload.py
+++ b/tests/repository/test_upload.py
@@ -101,6 +101,13 @@ def test_upload_file(client, requests_mocker, tmpdir, caplog):
     assert import_request["unit_key"] == import_unit_key
 
     messages = caplog.messages
+
+    # It should tell us about the upload
+    assert (
+        "Uploading some-file.txt to repo1 [cfb1fed0-752b-439e-aa68-fba68eababa3]"
+        in messages
+    )
+
     # task's spawned and completed
     assert "Created Pulp task: task1" in messages
     assert "Pulp task completed: task1" in messages
@@ -147,7 +154,7 @@ def test_upload_file_contains_unicode(client, requests_mocker):
     repo = FileRepository(id=repo_id)
     repo.__dict__["_client"] = client
 
-    upload_f = client._do_upload_file(upload_id, file_obj, "file.txt")
+    upload_f = client._do_upload_file(upload_id, file_obj)
 
     assert upload_f.result() == (
         "478f4808df7898528c7f13dc840aa321c4109f5c9f33bad7afcffc0253d4ff8f",


### PR DESCRIPTION
In preparation for the introduction of upload_rpm, let's fix a few
minor issues with upload_file. This is done so that upload_rpm and
other later upload methods can be consistent with upload_file, without
having to reproduce the same bugs.

Includes:

- internal refactoring in _do_upload_file so it can be reused for all
  kinds of content (the 'name' argument is specific to iso units)

- fixed unnecessary blocking while requesting upload ID, which would
  have prevented any concurrency during uploads

- more detailed logging which includes the repo and the upload ID

- fixed minor grammatical issues in docs

- changed so that the client always takes care of close() on the passed
  file object (and clarified this in docs). Since the API is
  asynchronous, having the caller be responsible for close() invites
  bugs (e.g. a 'with' statement around upload will not work as one might
  naively expect)