### PR TITLE
Add content_type_id attr to ModuldemdDefaultsUnit class

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -25,6 +25,10 @@ class ModulemdDefaultsUnit(Unit):
     profiles = pulp_attrib(type=dict, pulp_field="profiles", default=None)
     """The profiles of this modulemd defaults unit."""
 
+    content_type_id = pulp_attrib(
+        default="modulemd_defaults", type=str, pulp_field="_content_type_id"
+    )
+
     repository_memberships = pulp_attrib(
         default=None,
         type=list,


### PR DESCRIPTION
The attribute called 'content_type_id' seems to be defined
in all other *Unit classes but was probably missed from the
ModulemdDefaultsUnit class. So let's add this there now,
it makes instatiation of object of this class easier especially
for testing.