### PR TITLE
Add support for uploading modulemd streams

### DIFF
--- a/examples/upload-files
+++ b/examples/upload-files
@@ -19,6 +19,9 @@ def upload_to_repo(repo, path):
         if path.endswith(".rpm"):
             return repo.upload_rpm(path)
 
+        if path.endswith("modules.yaml") or path.endswith("modules.yml"):
+            return repo.upload_modules(path)
+
         # We can upload metadata file if the filename exactly matches a known
         # metadata type (e.g. "productid")
         basename = os.path.basename(path)

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -383,10 +383,14 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         upload_content = self._uploads_pending.pop(upload_id)
         upload_content.seek(0)
 
-        unit = units.make_unit(unit_type_id, unit_key, unit_metadata, upload_content)
-        unit = attr.evolve(unit, repository_memberships=[repo.id])
+        new_units = units.make_units(
+            unit_type_id, unit_key, unit_metadata, upload_content, repo_id
+        )
+        new_units = [
+            attr.evolve(u, repository_memberships=[repo.id]) for u in new_units
+        ]
 
-        self._insert_repo_units(repo_id, [unit])
+        self._insert_repo_units(repo_id, new_units)
 
         task = Task(id=self._next_task_id(), completed=True, succeeded=True)
 

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -32,7 +32,7 @@ class ModulemdUnit(Unit):
     is "201801".
     """
 
-    version = pulp_attrib(type=int, pulp_field="version")
+    version = pulp_attrib(type=int, pulp_field="version", converter=int)
     """The version of this module.
 
     Example: the version of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64

--- a/tests/data/sample-modules.yaml
+++ b/tests/data/sample-modules.yaml
@@ -1,0 +1,138 @@
+# This file has a small selection of modules taken from Fedora and used from
+# tests in this repo. Modules with a small number of packages were chosen to
+# keep test data from being larger than necessary. Other than that, the
+# selected modules are more or less arbitrary.
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: ant
+  modified: 202002242100
+  stream: 1.10
+  profiles:
+    1.10: [default]
+...
+---
+document: some-unknown-type
+comment: >
+  This is a made up document type to demonstrate Pulp's behavior of ignoring
+  unknown document types.
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado-vt
+  stream: "82lts"
+  version: 3420210902113311
+  context: 035be0ad
+  arch: x86_64
+  summary: Avocado Virt Test Plugin
+  description: >-
+    Avocado Virt Test is a plugin that lets you execute virt-tests with all the avocado
+    convenience features, such as HTML report, Xunit output, among others. This is
+    the '82lts' rolling stream that tracks with the most recent upstream release.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f34]
+    requires:
+      avocado: [82lts]
+      platform: [f34]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-vt.readthedocs.io/
+    tracker: https://pagure.io/avocado-vt/issues
+  profiles:
+    default:
+      description: Common profile installing the avocado-vt plugin.
+      rpms:
+      - python3-avocado-vt
+  api:
+    rpms:
+    - python3-avocado-vt
+  components:
+    rpms:
+      avocado-vt:
+        rationale: Avocado Virt Test Plugin
+        ref: 82lts
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.src
+    - python3-avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: dwm
+  modified: 202002242100
+  profiles:
+    6.0: [default]
+    6.1: [default]
+    6.2: [default]
+    latest: [default]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: dwm
+  stream: "6.0"
+  version: 3420210201213909
+  context: 058368ca
+  arch: x86_64
+  summary: Dynamic window manager for X
+  description: >-
+    dwm is a dynamic window manager for X.  It manages windows in tiled, monocle,
+    and floating layouts.  All of the layouts can be applied dynamically, optimizing
+    the environment for the application in use and the task performed.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f34]
+    requires:
+      platform: [f34]
+  references:
+    community: https://suckless.org/
+    documentation: https://dwm.suckless.org/
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distribution-compiled dwm as well as a helper script to
+        apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  api:
+    rpms:
+    - dwm
+    - dwm-user
+  components:
+    rpms:
+      dwm:
+        rationale: The main component of this module.
+        ref: 6.0
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - dwm-0:6.0-1.module_f34+11150+aec78cf8.src
+    - dwm-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-debuginfo-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-debugsource-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-user-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+...

--- a/tests/fake/test_fake_upload_modules.py
+++ b/tests/fake/test_fake_upload_modules.py
@@ -1,0 +1,119 @@
+import sys
+import os
+
+import pytest
+
+from pubtools.pulplib import (
+    FakeController,
+    YumRepository,
+    ModulemdUnit,
+    ModulemdDefaultsUnit,
+)
+
+
+@pytest.mark.parametrize("use_file_object", [False, True])
+def test_can_upload_units(use_file_object, data_path):
+    """repo.upload_modules() succeeds with fake client and populates units."""
+    modules_path = os.path.join(data_path, "sample-modules.yaml")
+
+    controller = FakeController()
+
+    controller.insert_repository(YumRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    to_upload = modules_path
+    if use_file_object:
+        to_upload = open(to_upload, "rb")
+
+    upload_f = repo1.upload_modules(to_upload)
+
+    # Upload should complete successfully.
+    tasks = upload_f.result()
+
+    # At least one task.
+    assert tasks
+
+    # Every task should have succeeded.
+    for t in tasks:
+        assert t.succeeded
+
+    # If I now search for content in that repo, or content across all repos...
+    units_in_repo = sorted(repo1.search_content().result(), key=repr)
+    units_all = sorted(client.search_content().result(), key=repr)
+
+    # They should be equal
+    assert units_all == units_in_repo
+
+    # And they should be this
+    assert units_in_repo == [
+        ModulemdDefaultsUnit(
+            name="ant",
+            repo_id="repo1",
+            # Note, this tests that 1.10 does not get coerced to 1.1,
+            # as happened in some tools previously.
+            stream="1.10",
+            profiles={"1.10": ["default"]},
+            content_type_id="modulemd_defaults",
+            repository_memberships=["repo1"],
+        ),
+        ModulemdDefaultsUnit(
+            name="dwm",
+            repo_id="repo1",
+            stream=None,
+            profiles={
+                "6.0": ["default"],
+                "6.1": ["default"],
+                "6.2": ["default"],
+                "latest": ["default"],
+            },
+            content_type_id="modulemd_defaults",
+            repository_memberships=["repo1"],
+        ),
+        ModulemdUnit(
+            name="avocado-vt",
+            stream="82lts",
+            version=3420210902113311,
+            context="035be0ad",
+            arch="x86_64",
+            content_type_id="modulemd",
+            repository_memberships=["repo1"],
+            artifacts=[
+                "avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.src",
+                "python3-avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.noarch",
+            ],
+            profiles={
+                "default": {
+                    "description": "Common profile installing the avocado-vt plugin.",
+                    "rpms": ["python3-avocado-vt"],
+                }
+            },
+        ),
+        ModulemdUnit(
+            name="dwm",
+            stream="6.0",
+            version=3420210201213909,
+            context="058368ca",
+            arch="x86_64",
+            content_type_id="modulemd",
+            repository_memberships=["repo1"],
+            artifacts=[
+                "dwm-0:6.0-1.module_f34+11150+aec78cf8.src",
+                "dwm-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                "dwm-debuginfo-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                "dwm-debugsource-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                "dwm-user-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+            ],
+            profiles={
+                "default": {
+                    "description": "The minimal, distribution-compiled dwm binary.",
+                    "rpms": ["dwm"],
+                },
+                "user": {
+                    "description": "Includes distribution-compiled dwm as well as a helper script to apply user patches and configuration, dwm-user.",
+                    "rpms": ["dwm", "dwm-user"],
+                },
+            },
+        ),
+    ]


### PR DESCRIPTION
Support uploading a YAML file with modulemd and modulemd-defaults
documents. The upload code is trivial, since Pulp takes care of
parsing the documents.

As usual, most of the complexity is in the fake Pulp client which needs
to reproduce compatible upload behavior as a real Pulp. This uses the
existing modulemd unit classes. Some minor refactoring is needed because
this is the first type of upload which (1) can produce more than one
unit from a single upload, and (2) produces a different unit depending
on which repo is the target of the upload.