### PR TITLE
Fix overly strict YumRepoMetadataFileUnit

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/repo_metadata.py
+++ b/pubtools/pulplib/_impl/model/unit/repo_metadata.py
@@ -17,9 +17,12 @@ class YumRepoMetadataFileUnit(Unit):
     """The type of this metadata file, e.g. "productid"."""
 
     sha256sum = pulp_attrib(
-        type=str, pulp_field="checksum", converter=lambda s: s.lower() if s else s
+        type=str,
+        pulp_field="checksum",
+        converter=lambda s: s.lower() if s else s,
+        default=None,
     )
-    """SHA256 checksum of this metadata file, as a hex string."""
+    """SHA256 checksum of this metadata file, if known, as a hex string."""
 
     content_type_id = pulp_attrib(
         default="yum_repo_metadata_file", type=str, pulp_field="_content_type_id"

--- a/tests/repository/test_remove_content.py
+++ b/tests/repository/test_remove_content.py
@@ -12,6 +12,7 @@ from pubtools.pulplib import (
     RpmUnit,
     FileUnit,
     ModulemdUnit,
+    YumRepoMetadataFileUnit,
     Unit,
 )
 
@@ -116,6 +117,10 @@ def test_remove_loads_units(fast_poller, requests_mocker, client):
                 "arch": "s390x",
             },
         },
+        {
+            "type_id": "yum_repo_metadata_file",
+            "unit_key": {"data_type": "productid", "repo_id": "some-repo"},
+        },
         {"type_id": "bizarre_type", "unit_key": {"whatever": "data"}},
     ]
 
@@ -159,6 +164,9 @@ def test_remove_loads_units(fast_poller, requests_mocker, client):
             ),
             ModulemdUnit(
                 name="module", stream="s1", version=1234, context="a1b2c3", arch="s390x"
+            ),
+            YumRepoMetadataFileUnit(
+                data_type="productid", content_type_id="yum_repo_metadata_file"
             ),
             Unit(content_type_id="bizarre_type"),
         ]


### PR DESCRIPTION
The sha256sum field on this model can't be mandatory because it's not a
part of the unit key. Responses from some Pulp APIs such as removing or
copying content will only include unit key fields, so it must be
possible to create a Unit with only those fields.

Fix it to make sha256sum optional and ensure this is covered from a
test.