### PR TITLE
Introduce copy_content for copying between repos

### DIFF
--- a/examples/copy-units
+++ b/examples/copy-units
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+import os
+import logging
+import sys
+from argparse import ArgumentParser
+
+from pubtools.pulplib import Client, Criteria, FakeController, Repository
+import pubtools.pulplib
+
+log = logging.getLogger("copy-units")
+
+
+def make_client(args):
+    auth = None
+
+    if args.url == "fake":
+        ctrl = FakeController()
+        ctrl.insert_repository(Repository(id=args.src))
+        ctrl.insert_repository(Repository(id=args.dest))
+        return ctrl.client
+
+    if args.username:
+        password = args.password
+        if password is None:
+            password = os.environ.get("PULP_PASSWORD")
+        if not password:
+            log.warning("No password provided for %s", args.username)
+        auth = (args.username, args.password)
+
+    return Client(args.url, auth=auth, verify=not args.insecure)
+
+
+def parsed_criteria(crit_args):
+    if not crit_args:
+        # No arguments => no criteria => everything is matched.
+        return [None]
+
+    # If there are args, each one should have a format like this:
+    #
+    #   "SomeUnit.some_field=some_val"
+    #
+    # We do not support any more complex criteria than exact field matches,
+    # nor any non-string types.
+    crit_per_unit_type = {}
+    for arg in crit_args:
+        try:
+            (key, val) = arg.split("=", 1)
+            (unit_type, field) = key.split(".", 1)
+
+            # A sanity check to prevent usage of unexpected classes
+            if not unit_type.endswith("Unit"):
+                raise ValueError("%s is not a valid unit type" % unit_type)
+
+            field_crit = Criteria.with_field(field, val)
+            if unit_type in crit_per_unit_type:
+                crit_per_unit_type[unit_type] = Criteria.and_(
+                    crit_per_unit_type[unit_type], field_crit
+                )
+            else:
+                crit_per_unit_type[unit_type] = field_crit
+        except:
+            log.exception("Error parsing criteria arg %s", arg)
+            log.error("Invalid criteria provided, cannot continue!")
+            sys.exit(3)
+
+    # Now resolve the unit_type strings into actual classes.
+    crit_resolved = []
+    for (unit_type_str, crit) in crit_per_unit_type.items():
+        unit_type = getattr(pubtools.pulplib, unit_type_str)
+        crit_resolved.append(Criteria.and_(crit, Criteria.with_unit_type(unit_type)))
+
+    return crit_resolved
+
+
+def do_copy(args, client):
+    # Convert user's criteria arguments into pulplib objects.
+    criteria_per_type = parsed_criteria(args.criteria)
+
+    # Look up the src and dest repo.
+    src_repo = client.get_repository(args.src)
+    dest_repo = client.get_repository(args.dest)
+
+    # Resolve the futures now so we crash ASAP if either repo is missing.
+    (src_repo, dest_repo) = (src_repo.result(), dest_repo.result())
+
+    # Copy everything.
+    # It's not currently permitted to mix different unit types in a single copy,
+    # so we have a list of criteria and we need to start a different copy for each.
+    copies = []
+    for crit in criteria_per_type:
+        copies.append(client.copy_content(src_repo, dest_repo, crit))
+
+    # Collect all the tasks spawned by copy.
+    tasks = []
+    for copy in copies:
+        tasks.extend(copy.result())
+
+    # Log copied units
+    units = sum([t.units for t in tasks], [])
+    units = sorted(units, key=repr)
+
+    log.info("Copied %s unit(s) from %s to %s:", len(units), args.src, args.dest)
+    for u in units:
+        log.info("   %s", u)
+
+
+def main():
+    log.setLevel(logging.INFO)
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+    parser = ArgumentParser(description="Copy units from one repository to another.")
+    parser.add_argument(
+        "--url", help="Pulp server URL, or 'fake' to use fake client", required=True
+    )
+    parser.add_argument("--username", help="Pulp username")
+    parser.add_argument(
+        "--password", help="Pulp password (or set PULP_PASSWORD in env)"
+    )
+    parser.add_argument("--src", action="store", required=True, help="Source repo ID")
+    parser.add_argument(
+        "--dest", action="store", required=True, help="Destination repo ID"
+    )
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--insecure", default=False, action="store_true")
+    parser.add_argument(
+        "criteria",
+        nargs="*",
+        help=(
+            "Criteria to filter copied content, of the form 'UnitType.field=value'; "
+            "e.g. 'RpmUnit.name=bash'."
+        ),
+    )
+
+    p = parser.parse_args()
+
+    if p.debug:
+        logging.getLogger("pubtools.pulplib").setLevel(logging.DEBUG)
+        log.setLevel(logging.DEBUG)
+
+    client = make_client(p)
+    do_copy(p, client)
+
+
+if __name__ == "__main__":
+    main()

--- a/pubtools/pulplib/_impl/fake/units.py
+++ b/pubtools/pulplib/_impl/fake/units.py
@@ -14,6 +14,7 @@ from pubtools.pulplib import (
 )
 
 from .rpmlib import get_rpm_header, get_header_fields, get_keys_from_header
+from ..model.attr import PULP2_UNIT_KEY
 
 LOG = logging.getLogger("pubtools.pulplib")
 
@@ -208,3 +209,20 @@ def make_unit_key(unit):
     raise NotImplementedError(
         "fake client does not support '%s'" % unit
     )  # pragma: no cover
+
+
+def with_key_only(units):
+    # Given some units, returns copies of those units with only unit_key
+    # fields present; mimics the behavior of pulp when filling units_successful
+    # field on tasks.
+    out = []
+    for unit in units:
+        klass = type(unit)
+        kwargs = {}
+        for field in attr.fields(klass):
+            if field.metadata.get(PULP2_UNIT_KEY):
+                kwargs[field.name] = getattr(unit, field.name)
+
+        out.append(klass(**kwargs))
+
+    return out

--- a/pubtools/pulplib/_impl/model/attr.py
+++ b/pubtools/pulplib/_impl/model/attr.py
@@ -7,6 +7,9 @@ from pubtools.pulplib._impl import compat_attr as attr
 # field in Pulp (if it exists)
 PULP2_FIELD = "_pubtools.pulplib.pulp2_field"
 
+# attr metadata private key indicating whether a field is part of the unit_key.
+PULP2_UNIT_KEY = "_pubtools.pulplib.pulp2_unit_key"
+
 # attr metadata private key for converting from a pulp2 representation and a Python
 # object.
 # Why not using attr.ib built-in 'converter'?  Because that makes it public API,
@@ -20,7 +23,11 @@ PY_PULP2_CONVERTER = "_pubtools.pulplib.py_to_pulp2_converter"
 
 
 def pulp_attrib(
-    pulp_field=None, pulp_py_converter=None, py_pulp_converter=None, **kwargs
+    pulp_field=None,
+    pulp_py_converter=None,
+    py_pulp_converter=None,
+    unit_key=None,
+    **kwargs
 ):
     """Drop-in replacement for attr.ib with added features:
 
@@ -37,6 +44,9 @@ def pulp_attrib(
 
     if py_pulp_converter:
         metadata[PY_PULP2_CONVERTER] = py_pulp_converter
+
+    if unit_key is not None:
+        metadata[PULP2_UNIT_KEY] = unit_key
 
     if "type" in kwargs:
         # As a convenience, you may define string types as type=str

--- a/pubtools/pulplib/_impl/model/task.py
+++ b/pubtools/pulplib/_impl/model/task.py
@@ -63,6 +63,9 @@ class Task(PulpObject):
          "pulp:action:publish"]
     """
 
+    # TODO: is it a bug that this only allows a single repo ID??
+    # Some tasks, like copy, involve multiple repos. We'll only include
+    # the first repo ID from tags here... seems arbitrary.
     repo_id = pulp_attrib(type=str)
     """The ID of the repository associated with this task, otherwise None."""
 

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -13,18 +13,21 @@ class FileUnit(Unit):
     .. versionadded:: 1.5.0
     """
 
-    path = pulp_attrib(type=str, pulp_field="name")
+    path = pulp_attrib(type=str, pulp_field="name", unit_key=True)
     """Full path for this file in the Pulp repository.
 
     This may include leading directory components, but
     in the common case, this is only a basename.
     """
 
-    size = pulp_attrib(type=int, converter=int, pulp_field="size")
+    size = pulp_attrib(type=int, converter=int, pulp_field="size", unit_key=True)
     """Size of this file, in bytes."""
 
     sha256sum = pulp_attrib(
-        type=str, pulp_field="checksum", converter=lambda s: s.lower() if s else s
+        type=str,
+        pulp_field="checksum",
+        converter=lambda s: s.lower() if s else s,
+        unit_key=True,
     )
     """SHA256 checksum of this file, as a hex string."""
 

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -15,35 +15,35 @@ class ModulemdUnit(Unit):
     .. versionadded:: 1.5.0
     """
 
-    name = pulp_attrib(type=str, pulp_field="name")
+    name = pulp_attrib(type=str, pulp_field="name", unit_key=True)
     """The name of this module.
 
     Example: the name of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64
     is "javapackages-tools".
     """
 
-    stream = pulp_attrib(type=str, pulp_field="stream")
+    stream = pulp_attrib(type=str, pulp_field="stream", unit_key=True)
     """The stream of this module.
 
     Example: the stream of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64
     is "201801".
     """
 
-    version = pulp_attrib(type=int, pulp_field="version", converter=int)
+    version = pulp_attrib(type=int, pulp_field="version", converter=int, unit_key=True)
     """The version of this module.
 
     Example: the version of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64
     is 20180813043155.
     """
 
-    context = pulp_attrib(type=str, pulp_field="context")
+    context = pulp_attrib(type=str, pulp_field="context", unit_key=True)
     """The context of this module.
 
     Example: the context of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64
     is "dca7b4a4".
     """
 
-    arch = pulp_attrib(type=str, pulp_field="arch")
+    arch = pulp_attrib(type=str, pulp_field="arch", unit_key=True)
     """The architecture of this module.
 
     Example: the arch of javapackages-tools:201801:20180813043155:dca7b4a4:aarch64

--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -13,10 +13,10 @@ class ModulemdDefaultsUnit(Unit):
     .. versionadded:: 2.4.0
     """
 
-    name = pulp_attrib(type=str, pulp_field="name")
+    name = pulp_attrib(type=str, pulp_field="name", unit_key=True)
     """The name of this modulemd defaults unit"""
 
-    repo_id = pulp_attrib(type=str, pulp_field="repo_id")
+    repo_id = pulp_attrib(type=str, pulp_field="repo_id", unit_key=True)
     """The repository ID bound to this modulemd defaults unit"""
 
     stream = pulp_attrib(type=str, pulp_field="stream", default=None)

--- a/pubtools/pulplib/_impl/model/unit/repo_metadata.py
+++ b/pubtools/pulplib/_impl/model/unit/repo_metadata.py
@@ -13,7 +13,7 @@ class YumRepoMetadataFileUnit(Unit):
     .. versionadded:: 2.17.0
     """
 
-    data_type = pulp_attrib(type=str, pulp_field="data_type")
+    data_type = pulp_attrib(type=str, pulp_field="data_type", unit_key=True)
     """The type of this metadata file, e.g. "productid"."""
 
     sha256sum = pulp_attrib(

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -17,31 +17,31 @@ class RpmUnit(Unit):
     .. versionadded:: 1.5.0
     """
 
-    name = pulp_attrib(type=str, pulp_field="name")
+    name = pulp_attrib(type=str, pulp_field="name", unit_key=True)
     """The name of this RPM.
 
     Example: the name of bash-5.0.7-1.fc30.x86_64.rpm is "bash".
     """
 
-    version = pulp_attrib(type=str, pulp_field="version")
+    version = pulp_attrib(type=str, pulp_field="version", unit_key=True)
     """The version of this RPM.
 
     Example: the version of bash-5.0.7-1.fc30.x86_64.rpm is "5.0.7".
     """
 
-    release = pulp_attrib(type=str, pulp_field="release")
+    release = pulp_attrib(type=str, pulp_field="release", unit_key=True)
     """The release of this RPM.
 
     Example: the release of bash-5.0.7-1.fc30.x86_64.rpm is "1.fc30".
     """
 
-    arch = pulp_attrib(type=str, pulp_field="arch")
+    arch = pulp_attrib(type=str, pulp_field="arch", unit_key=True)
     """The architecture of this RPM.
 
     Example: the arch of bash-5.0.7-1.fc30.x86_64.rpm is "x86_64".
     """
 
-    epoch = pulp_attrib(default="0", type=str, pulp_field="epoch")
+    epoch = pulp_attrib(default="0", type=str, pulp_field="epoch", unit_key=True)
     """The epoch of this RPM (most commonly "0").
 
     Example: the epoch of 3:bash-5.0.7-1.fc30.x86_64.rpm is "3".
@@ -94,6 +94,7 @@ class RpmUnit(Unit):
         # https://github.com/pulp/pulp_rpm/blob/69759d0fb9a16c0a47b1f49c78f6712e650912e1/plugins/pulp_rpm/plugins/importers/yum/upload.py#L436
         pulp_field="checksum",
         converter=lambda s: s.lower() if s else s,
+        unit_key=True,
     )
     """SHA256 checksum of this RPM, as a hex string."""
 

--- a/tests/client/test_copy_content.py
+++ b/tests/client/test_copy_content.py
@@ -1,0 +1,143 @@
+from pubtools.pulplib import Repository, Task, RpmUnit, ModulemdUnit, Criteria, Matcher
+
+
+def test_copy_no_criteria(fast_poller, requests_mocker, client):
+    """Copy succeeds when given no criteria"""
+
+    src = Repository(id="src-repo")
+    dest = Repository(id="dest-repo")
+
+    src.__dict__["_client"] = client
+    dest.__dict__["_client"] = client
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/dest-repo/actions/associate/",
+        [{"json": {"spawned_tasks": [{"task_id": "task1"}, {"task_id": "task2"}]}}],
+    )
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        [
+            {
+                "json": [
+                    {
+                        "task_id": "task1",
+                        "state": "finished",
+                        "result": {
+                            "units_successful": [
+                                {
+                                    "type_id": "modulemd",
+                                    "unit_key": {
+                                        "name": "module",
+                                        "stream": "s1",
+                                        "version": 1234,
+                                        "context": "a1b2c3",
+                                        "arch": "s390x",
+                                    },
+                                }
+                            ]
+                        },
+                    },
+                    {"task_id": "task2", "state": "skipped"},
+                ]
+            }
+        ],
+    )
+
+    # Copy should succeed, and return the tasks with units parsed.
+    assert sorted(client.copy_content(src, dest), key=lambda t: t.id) == [
+        Task(
+            id="task1",
+            completed=True,
+            succeeded=True,
+            units=[
+                ModulemdUnit(
+                    name="module",
+                    stream="s1",
+                    version=1234,
+                    context="a1b2c3",
+                    arch="s390x",
+                    content_type_id="modulemd",
+                )
+            ],
+            units_data=[
+                {
+                    "type_id": "modulemd",
+                    "unit_key": {
+                        "name": "module",
+                        "stream": "s1",
+                        "version": 1234,
+                        "context": "a1b2c3",
+                        "arch": "s390x",
+                    },
+                }
+            ],
+        ),
+        Task(id="task2", completed=True, succeeded=True),
+    ]
+
+    hist = requests_mocker.request_history
+
+    # First request should have been the associate.
+    assert (
+        hist[0].url
+        == "https://pulp.example.com/pulp/api/v2/repositories/dest-repo/actions/associate/"
+    )
+
+    # It should have posted for the given source repo, with empty criteria.
+    assert hist[0].json() == {"criteria": {}, "source_repo_id": "src-repo"}
+
+
+def test_copy_with_criteria(fast_poller, requests_mocker, client):
+    """Copy with criteria succeeds, and serializes criteria correctly."""
+
+    src = Repository(id="src-repo")
+    dest = Repository(id="dest-repo")
+
+    src.__dict__["_client"] = client
+    dest.__dict__["_client"] = client
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/dest-repo/actions/associate/",
+        [{"json": {"spawned_tasks": [{"task_id": "task1"}, {"task_id": "task2"}]}}],
+    )
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        [
+            {
+                "json": [
+                    {"task_id": "task1", "state": "finished"},
+                    {"task_id": "task2", "state": "skipped"},
+                ]
+            }
+        ],
+    )
+
+    crit = Criteria.and_(
+        Criteria.with_unit_type(RpmUnit),
+        Criteria.with_field("name", Matcher.in_(["bash", "glibc"])),
+    )
+
+    # Copy should succeed, and return the tasks (in this case with no matches)
+    assert sorted(client.copy_content(src, dest, crit), key=lambda t: t.id) == [
+        Task(id="task1", completed=True, succeeded=True),
+        Task(id="task2", completed=True, succeeded=True),
+    ]
+
+    hist = requests_mocker.request_history
+
+    # First request should have been the associate.
+    assert (
+        hist[0].url
+        == "https://pulp.example.com/pulp/api/v2/repositories/dest-repo/actions/associate/"
+    )
+
+    # It should have encoded our criteria object as needed by the Pulp API.
+    assert hist[0].json() == {
+        "criteria": {
+            "filters": {"unit": {"name": {"$in": ["bash", "glibc"]}}},
+            "type_ids": ["rpm", "srpm"],
+        },
+        "source_repo_id": "src-repo",
+    }

--- a/tests/fake/test_fake_copy_content.py
+++ b/tests/fake/test_fake_copy_content.py
@@ -1,0 +1,155 @@
+import pytest
+
+from pubtools.pulplib import (
+    FakeController,
+    Criteria,
+    Matcher,
+    RpmUnit,
+    ModulemdUnit,
+    YumRepository,
+)
+
+
+@pytest.fixture
+def controller():
+    return FakeController()
+
+
+def test_copy_content_empty_repo(controller):
+    """copy_content from empty repo succeeds and copies nothing"""
+    src = YumRepository(id="empty-repo")
+    dest = YumRepository(id="dest-repo")
+    controller.insert_repository(src)
+    controller.insert_repository(dest)
+
+    client = controller.client
+
+    # Repos are initially detached, re-fetch them via client
+    src = client.get_repository(src.id).result()
+    dest = client.get_repository(dest.id).result()
+
+    # It should succeed
+    copy_tasks = list(client.copy_content(src, dest))
+
+    # It should have at least one task
+    assert copy_tasks
+
+    for t in copy_tasks:
+        # Every task should have succeeded
+        assert t.succeeded
+
+        # No units should have been copied
+        assert not t.units
+
+
+def test_copy_content_all(controller):
+    """copy_content with no criteria copies all units from a repo"""
+    src = YumRepository(id="src-repo")
+    dest = YumRepository(id="dest-repo")
+    other = YumRepository(id="other-repo")
+    controller.insert_repository(src)
+    controller.insert_repository(dest)
+    controller.insert_repository(other)
+
+    # Set up that both 'src' and 'other' contain some units.
+    # The units in 'other' are there to ensure that copying only
+    # happens from the given source repo and not other repos unexpectedly.
+    src_units = [
+        ModulemdUnit(
+            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+        ),
+        RpmUnit(
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+            # Note: the next two fields aren't part of the unit key on RPM units.
+            # We put these here specifically to verify they'll be filtered out
+            # on the copy response (as a real Pulp server does).
+            filename="bash-4.0-1.x86_64.rpm",
+            signing_key="a1b2c3",
+        ),
+    ]
+    controller.insert_units(src, src_units)
+    controller.insert_units(
+        other,
+        [
+            RpmUnit(
+                name="glibc",
+                version="5.0",
+                release="1",
+                arch="x86_64",
+                sourcerpm="glibc-5.0-1.el5_11.1.src.rpm",
+            )
+        ],
+    )
+
+    client = controller.client
+
+    # Repos are initially detached, re-fetch them via client
+    src = client.get_repository(src.id).result()
+    dest = client.get_repository(dest.id).result()
+
+    # It should succeed
+    copy_tasks = list(client.copy_content(src, dest))
+
+    # Gather all units apparently copied
+    units = sum([t.units for t in copy_tasks], [])
+
+    # It should copy just the units we expect, from src.
+    assert sorted(units, key=repr) == [
+        ModulemdUnit(
+            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+        ),
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64", epoch="0"),
+    ]
+
+    # The copy should also impact subsequent content searches.
+    dest_units = list(dest.search_content())
+    assert src_units == sorted(dest_units, key=repr)
+
+
+def test_copy_content_with_criteria(controller):
+    """copy_content can filter copied units by field values"""
+
+    src = YumRepository(id="src-repo")
+    dest = YumRepository(id="dest-repo")
+    controller.insert_repository(src)
+    controller.insert_repository(dest)
+
+    src_units = [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(name="bash", version="4.0", release="2", arch="x86_64"),
+        RpmUnit(name="bash", version="4.1", release="3", arch="x86_64"),
+        RpmUnit(name="glibc", version="5.0", release="1", arch="x86_64"),
+    ]
+    controller.insert_units(src, src_units)
+
+    client = controller.client
+
+    # Repos are initially detached, re-fetch them via client
+    src = client.get_repository(src.id).result()
+    dest = client.get_repository(dest.id).result()
+
+    # This is what we want to copy...
+    crit = Criteria.and_(
+        Criteria.with_field("name", "bash"),
+        Criteria.with_field("release", Matcher.in_(["1", "3"])),
+    )
+
+    # Copy should succeed
+    copy_tasks = list(client.copy_content(src, dest, crit))
+
+    # It should have copied only those units matching the criteria
+    units = sum([t.units for t in copy_tasks], [])
+    assert sorted(units, key=repr) == [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64", epoch="0"),
+        RpmUnit(name="bash", version="4.1", release="3", arch="x86_64", epoch="0"),
+    ]
+
+    # The copy should also impact subsequent content searches.
+    dest_units = list(dest.search_content())
+    assert sorted(dest_units, key=repr) == [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64", epoch="0"),
+        RpmUnit(name="bash", version="4.1", release="3", arch="x86_64", epoch="0"),
+    ]


### PR DESCRIPTION
This method provides access to the 'associate' action to get units from
one repo to another. It aims to have consistent behavior with the
existing 'search_content' method with respect to criteria handling; the
difference is that the searched units are put into a target repo, rather
than simply returned.

In order for the FakeClient to provide accurate behavior around
units_successful on completed tasks, it was necessary to add a new
pieces of metadata on fields denoting whether or not they make up part
of the unit_key, as only those fields are exposed after a copy.

A fully functional example script is included which can use the new
method to copy between repos with basic filtering.

Some design choices here are worth pointing out:

## Location of method

  Copying involves a source and destination repo. The method to request
  a copy could have been added to the source repo, destination repo, or
  no repo at all (the client).

  I decided that the client is the best place, because neither the
  source nor destination repo seems obviously correct (so in practice
  it'd probably be hard to remember when using the API), and also to
  avoid emphasizing either repo as more important than the other in the
  operation (considering that both of them will be locked during the
  copy).

## Repo IDs vs objects

  The method could have accepted just repo IDs, or it could require
  objects.

  I decided to make it require Repository objects due to the expectation
  that we'll eventually have requirements to change the copy behavior
  based on certain properties of the repo (e.g. "if x is in repo notes,
  then y must be set in override_config"). If there's any chance we need
  full Repository objects to do a copy, it's best to require the caller
  to provide them up-front, because only the caller knows the most
  efficient way to query all repos in scope for their current task.