### PR TITLE
Fix FileUnit.size edge cases

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -20,7 +20,7 @@ class FileUnit(Unit):
     in the common case, this is only a basename.
     """
 
-    size = pulp_attrib(type=int, pulp_field="size")
+    size = pulp_attrib(type=int, converter=int, pulp_field="size")
     """Size of this file, in bytes."""
 
     sha256sum = pulp_attrib(

--- a/pubtools/pulplib/_impl/schema/unit.yaml
+++ b/pubtools/pulplib/_impl/schema/unit.yaml
@@ -26,7 +26,10 @@ definitions:
 
       # Size in bytes
       size:
-        type: integer
+        # Ideally would be 'integer', but some old units have been stored
+        # as non-integers, e.g.
+        # RHEL4-U5-ia64-source-disc2.iso => 512251904.0
+        type: number
 
       repository_memberships:
         type: array

--- a/pubtools/pulplib/_impl/util.py
+++ b/pubtools/pulplib/_impl/util.py
@@ -13,7 +13,7 @@ def lookup(value, key, default=ABSENT):
 
     while value and value is not ABSENT and keys:
         next_key = keys.pop(0)
-        value = value.get(next_key) or ABSENT
+        value = value.get(next_key, ABSENT)
 
     if (value is ABSENT) or keys:
         # it's not present

--- a/tests/unit/test_file_unit.py
+++ b/tests/unit/test_file_unit.py
@@ -1,0 +1,41 @@
+from pubtools.pulplib import FileUnit
+
+
+def test_noninteger_size():
+    """FileUnit.from_data accepts a floating point size."""
+
+    loaded = FileUnit.from_data(
+        {
+            "_content_type_id": "iso",
+            "name": "my-impossible-file",
+            "checksum": "49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+            "size": 123.4,
+        }
+    )
+
+    assert loaded == FileUnit(
+        path="my-impossible-file",
+        size=123,
+        sha256sum="49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+        content_type_id="iso",
+    )
+
+
+def test_zero_size():
+    """FileUnit.from_data accepts a size of zero."""
+
+    loaded = FileUnit.from_data(
+        {
+            "_content_type_id": "iso",
+            "name": "my-empty-file",
+            "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "size": 0,
+        }
+    )
+
+    assert loaded == FileUnit(
+        path="my-empty-file",
+        size=0,
+        sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        content_type_id="iso",
+    )


### PR DESCRIPTION
Attempting to load all file units from a real Pulp showed a couple of
edge cases not working:

- some older data is stored with a non-integer 'size', so this has to be
  tolerated on load

- a size value of 0 was wrongly treated as an absent size (this bug
  could potentially have affected other unit types too).

Fix them both and add a test to cover them.