### PR TITLE
tests: fix lifetime of test client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ def client():
     - client has a retry policy configured so that all sleeps are very fast
       (avoids delays due to retry in autotests)
     """
-    return FastRetryClient("https://pulp.example.com/")
+    with FastRetryClient("https://pulp.example.com/") as client:
+        yield client
 
 
 @pytest.fixture


### PR DESCRIPTION
Client objects support the context manager protocol. We should use it in
the fixture here.

If left out it is possible for some background HTTP requests from the
client to outlive the requests_mocker fixture and therefore attempt to
do real HTTP requests. This shouldn't cause test failures but can cause
confusing warnings during test shutdown.