### PR TITLE
Fix too strict 'task' schema

### DIFF
--- a/pubtools/pulplib/_impl/schema/task.yaml
+++ b/pubtools/pulplib/_impl/schema/task.yaml
@@ -69,8 +69,12 @@ properties:
   # Task result. The content depends on the task type.
   result:
     anyOf:
-    - type: "null"
-    - type: array
+
+    # If it's not an object, we don't care what it is, just accept it.
+    - not:
+        type: object
+
+    # If it is an object, we will validate some inner fields.
     - type: object
       properties:
         # For tasks operating on units (e.g. assoc/unassoc), this element

--- a/pubtools/pulplib/_impl/util.py
+++ b/pubtools/pulplib/_impl/util.py
@@ -11,7 +11,7 @@ def lookup(value, key, default=ABSENT):
     # Otherwise, KeyError is raised, similar as for a regular dict lookup.
     keys = key.split(".")
 
-    while value and value is not ABSENT and keys:
+    while value and isinstance(value, dict) and keys:
         next_key = keys.pop(0)
         value = value.get(next_key, ABSENT)
 

--- a/tests/task/test_task_from_data.py
+++ b/tests/task/test_task_from_data.py
@@ -17,6 +17,18 @@ def test_successful_task():
     assert task == Task(id="some-task", completed=True, succeeded=True)
 
 
+def test_integer_result():
+    """from_data tolerates integer values in 'result' field.
+
+    This test exists because the 'result' field can contain different types
+    (e.g. None, integer, dict) based on the type of task which was executed.
+    In some cases, we want to parse the dict. The test protects against
+    unconditionally assuming we always have a dict.
+    """
+    task = Task.from_data({"task_id": "some-task", "state": "finished", "result": 123})
+    assert task == Task(id="some-task", completed=True, succeeded=True)
+
+
 def test_failed_task():
     """from_data sets attributes appropriately for a failed task"""
     task = Task.from_data({"task_id": "some-task", "state": "error"})


### PR DESCRIPTION
Task data from Pulp comes with a result field, but no specific type is
enforced for the field - different plugins and task types will produce
different types of result.

In the case of a "clear orphans" task, the result would be an integer
(presumably the number of orphans deleted). That would cause a crash on
the schema and the underlying code which assumed a truthy value would
always be a dict.

Make the schema and related code more tolerant of other types so that
tasks of this form can be loaded.