### PR TITLE
Support upload of comps.xml

### DIFF
--- a/examples/upload-files
+++ b/examples/upload-files
@@ -22,6 +22,9 @@ def upload_to_repo(repo, path):
         if path.endswith("modules.yaml") or path.endswith("modules.yml"):
             return repo.upload_modules(path)
 
+        if path.endswith("comps.xml"):
+            return repo.upload_comps_xml(path)
+
         # We can upload metadata file if the filename exactly matches a known
         # metadata type (e.g. "productid")
         basename = os.path.basename(path)

--- a/pubtools/pulplib/_impl/comps.py
+++ b/pubtools/pulplib/_impl/comps.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+
+from xml.parsers import expat
+
+from six import StringIO
+
+
+class BooleanStringIO(StringIO):
+    """A StringIO which coerces the output value into a boolean."""
+
+    def getvalue(self):
+        # Note: StringIO in python2 is an old-style class, so no super().
+        value = StringIO.getvalue(self).strip()
+        if value.lower() in ("false", ""):
+            return False
+        return True
+
+
+class IntegerStringIO(StringIO):
+    """A StringIO which coerces the output value into an integer."""
+
+    def getvalue(self):
+        value = StringIO.getvalue(self).strip()
+        if not value:
+            return None
+        return int(value)
+
+
+def close_buffers(value):
+    """Returns a copy of 'value' with all StringIO buffers replaced with the
+    content of each buffer.
+
+    This is used at the end of parsing, once we know that no more text data can
+    arrive, to seal the output and convert into a serializable form.
+    """
+
+    if isinstance(value, list):
+        return [close_buffers(elem) for elem in value]
+
+    if isinstance(value, dict):
+        out = {}
+        for (key, elem) in value.items():
+            out[key] = close_buffers(elem)
+        return out
+
+    if isinstance(value, StringIO):
+        return value.getvalue()
+
+    return value
+
+
+class CompsParser(object):
+    """A stateful parser for comps.xml data.
+
+    This parser wraps xml.parsers.expat and installs handlers which are able to
+    load XML elements into the form used by Pulp for the relevant unit types.
+    """
+
+    def __init__(self):
+        self.raw_parser = expat.ParserCreate()
+
+        # Current parse state. The output is ultimately returned from 'units'.
+        self.units = []
+        self.current_buf = StringIO()
+        self.current_unit = {}
+        self.current_path = []
+
+        # Bind ourselves to expat.
+        for name in dir(self):
+            if name.endswith("Handler"):
+                setattr(self.raw_parser, name, getattr(self, name))
+
+    def parse(self, io):
+        """Parse comps XML from io, a file-like object in binary mode.
+
+        Returns parsed units in Pulp form (i.e. a list of dicts with each dict
+        having the Pulp-specific attributes such as _content_type_id, ...)
+        """
+        self.units = []
+        self.current_unit = {}
+        self.current_path = []
+        self.raw_parser.ParseFile(io)
+        self.units = close_buffers(self.units)
+        return self.units
+
+    ########################## Shared handlers #########################
+    # Handle some basic tags shared by multiple types such as:
+    #
+    #     <id>kde-desktop-environment</id>
+    #     <name>KDE Desktop</name>
+    #     <name xml:lang="af">KDE-werkskerm</name>
+    #     <name xml:lang="as">KDE ডেস্কটপ</name>
+    #     ...
+    #     <description>The KDE SC includes ...</description>
+    #     <description xml:lang="ar">الـ KDE SC يتضمن سطح...</description>
+
+    def handle_text_elem(self, tag, attrs):
+        if tag in ("name", "description") and attrs.get("xml:lang"):
+            # Elem like this: <name xml:lang="af">3D-drukwerk</name>
+            # Is parsed into: translated_name["af"] = "3D-drukwerk"
+            tag = "translated_" + tag
+            lang = attrs["xml:lang"]
+            self.current_buf = StringIO()
+            self.current_unit.setdefault(tag, {})[lang] = self.current_buf
+            return True
+
+        elif tag in ("id", "name", "description"):
+            self.current_buf = StringIO()
+            self.current_unit[tag] = self.current_buf
+            return True
+
+        return False
+
+    def handle_display_order_tag(self, tag):
+        if tag == "display_order":
+            self.current_buf = IntegerStringIO()
+            self.current_unit[tag] = self.current_buf
+            return True
+        return False
+
+    ########################## Group ###################################
+    #   <group>
+    #     <id>3d-printing</id>
+    #     <name>3D Printing</name>
+    #     <name xml:lang="af">3D-drukwerk</name>
+    #     <name xml:lang="bg">3D Печатане</name>
+    #     ...
+    #     <description>3D printing software</description>
+    #     <description xml:lang="af">3D-druksagteware</description>
+    #     <description xml:lang="bg">Софтуер за 3D печатане</description>
+    #     ...
+    #     <default>false</default>
+    #     <uservisible>true</uservisible>
+    #     <packagelist>
+    #       <packagereq type="default">admesh</packagereq>
+    #       <packagereq type="default">blender</packagereq>
+    #       ...
+    #     </packagelist>
+    #   </group>
+
+    def start_group_elem(self):
+        self.current_unit = {"_content_type_id": "package_group"}
+        self.units.append(self.current_unit)
+
+    def handle_group_tag(self, tag, attrs):
+        if self.handle_text_elem(tag, attrs):
+            return
+
+        elif tag in ("default", "uservisible"):
+            self.current_buf = BooleanStringIO()
+            if tag == "uservisible":
+                tag = "user_visible"
+            self.current_unit[tag] = self.current_buf
+
+    def handle_group_packagelist(self, attrs):
+        package_type = attrs.get("type") or "mandatory"
+        key = package_type + "_package_names"
+        self.current_buf = StringIO()
+        target = self.current_unit.setdefault(key, [])
+
+        if package_type == "conditional":
+            # "conditional" type is special, a requires attrib is included, and Pulp
+            # stores a (pkgname, requires) tuple.
+            target.append([self.current_buf, attrs.get("requires")])
+        else:
+            # Anything else just stores the package name.
+            target.append(self.current_buf)
+
+    def handle_group_elem(self, path, attrs):
+        if path == []:
+            return self.start_group_elem()
+
+        if len(path) == 1:
+            return self.handle_group_tag(path[0], attrs)
+
+        if path == ["packagelist", "packagereq"]:
+            return self.handle_group_packagelist(attrs)
+
+    ########################## Environment ################################
+    #   <environment>
+    #     <id>cloud-server-environment</id>
+    #     <name>Fedora Cloud Server</name>
+    #     <name xml:lang="af">Fedora-wolkbediener</name>
+    #     <name xml:lang="bg">Fedora Cloud Сървър</name>
+    #     ...
+    #     <description>A server install with components needed...</description>
+    #     <description xml:lang="af">’n Bedienerinstallasie met die nodige...</description>
+    #     ...
+    #     <display_order>3</display_order>
+    #     <grouplist>
+    #       <groupid>cloud-server</groupid>
+    #       <groupid>core</groupid>
+    #     </grouplist>
+    #     <optionlist>
+    #       <groupid>directory-server</groupid>
+    #       <groupid>dns-server</groupid>
+    #       ...
+    #     </optionlist>
+    #   </environment>
+
+    def start_environment_elem(self):
+        self.current_unit = {"_content_type_id": "package_environment"}
+        self.units.append(self.current_unit)
+
+    def handle_environment_tag(self, tag, attrs):
+        if self.handle_text_elem(tag, attrs):
+            return
+
+        self.handle_display_order_tag(tag)
+
+    def handle_environment_grouplist(self):
+        self.current_buf = StringIO()
+        self.current_unit.setdefault("group_ids", []).append(self.current_buf)
+
+    def handle_environment_optionlist(self, attrs):
+        self.current_buf = StringIO()
+
+        option = {"group": self.current_buf}
+
+        if (attrs.get("default") or "").lower() == "true":
+            option["default"] = True
+
+        self.current_unit.setdefault("options", []).append(option)
+
+    def handle_environment_elem(self, path, attrs):
+        if path == []:
+            return self.start_environment_elem()
+
+        if len(path) == 1:
+            return self.handle_environment_tag(path[0], attrs)
+
+        if path == ["grouplist", "groupid"]:
+            return self.handle_environment_grouplist()
+
+        if path == ["optionlist", "groupid"]:
+            return self.handle_environment_optionlist(attrs)
+
+    ########################## Category ###################################
+    #   <category>
+    #     <id>kde-desktop-environment</id>
+    #     <name>KDE Desktop</name>
+    #     <name xml:lang="af">KDE-werkskerm</name>
+    #     <name xml:lang="as">KDE ডেস্কটপ</name>
+    #     ...
+    #     <description>The KDE SC includes ...</description>
+    #     <description xml:lang="ar">الـ KDE SC يتضمن سطح...</description>
+    #     <display_order>10</display_order>
+    #     <grouplist>
+    #       <groupid>kde-apps</groupid>
+    #       <groupid>kde-desktop</groupid>
+    #       ...
+    #     </grouplist>
+    #   </category>
+
+    def start_category_elem(self):
+        self.current_unit = {"_content_type_id": "package_category"}
+        self.units.append(self.current_unit)
+
+    def handle_category_tag(self, tag, attrs):
+        if self.handle_text_elem(tag, attrs):
+            return
+
+        self.handle_display_order_tag(tag)
+
+    def handle_category_grouplist(self):
+        self.current_buf = StringIO()
+        self.current_unit.setdefault("packagegroupids", []).append(self.current_buf)
+
+    def handle_category_elem(self, path, attrs):
+        if path == []:
+            return self.start_category_elem()
+
+        if len(path) == 1:
+            return self.handle_category_tag(path[0], attrs)
+
+        if path == ["grouplist", "groupid"]:
+            return self.handle_category_grouplist()
+
+    ####################### Langpacks #####################################
+    # <langpacks>
+    #     <match install="LabPlot-doc-%s" name="LabPlot-doc"/>
+    #     <match install="aspell-%s" name="aspell"/>
+    #     ...
+    # </langpacks>
+
+    def start_langpacks_elem(self):
+        self.current_unit = {"_content_type_id": "package_langpacks"}
+        self.units.append(self.current_unit)
+
+    def handle_langpacks_match(self, attrs):
+        self.current_unit.setdefault("matches", []).append(
+            {"install": attrs.get("install"), "name": attrs.get("name")}
+        )
+
+    def handle_langpacks_elem(self, path, attrs):
+        if path == []:
+            return self.start_langpacks_elem()
+
+        if path == ["match"]:
+            return self.handle_langpacks_match(attrs)
+
+    ####################### Handlers ######################################
+    # All of these are installed on the expat parser.
+    #
+    # The name of each method must exactly match the names documented at
+    # xml.parsers.expat.
+    #
+    # These handlers dispatch to the rest of the code above to parse elements
+    # once the type is known.
+
+    def StartElementHandler(self, name, attrs):
+        self.current_path.append(name)
+
+        prefix = self.current_path[:2]
+        rest = self.current_path[2:]
+
+        if prefix == ["comps", "group"]:
+            return self.handle_group_elem(rest, attrs)
+
+        if prefix == ["comps", "category"]:
+            return self.handle_category_elem(rest, attrs)
+
+        if prefix == ["comps", "environment"]:
+            return self.handle_environment_elem(rest, attrs)
+
+        if prefix == ["comps", "langpacks"]:
+            return self.handle_langpacks_elem(rest, attrs)
+
+    def CharacterDataHandler(self, data):
+        self.current_buf.write(data)
+
+    def EndElementHandler(self, _name):
+        self.current_path = self.current_path[:-1]
+        self.current_buf = StringIO()
+
+
+def units_for_xml(io):
+    """Parse comps.xml from a file-like object and return corresponding Pulp units.
+
+    Arguments:
+        io (file object)
+            A file-like object.
+
+            Should be opened in binary mode, and should point at bytes making up
+            a valid comps.xml document encoded with UTF-8, UTF-16, ISO-8859-1 (Latin1)
+            or ASCII.
+
+    Returns:
+        list[dict]
+            A list of unit metadata in the form used by Pulp2 for unit types relating
+            to comps.xml (e.g. package_group, package_langpacks, ...).
+
+            Returned units omit the 'repo_id' attribute, which must be filled in if
+            units will be uploaded to a specific repo.
+
+    Note: this is the only function in this module intended to be used from other
+    modules.
+    """
+    parser = CompsParser()
+    return parser.parse(io)

--- a/pubtools/pulplib/_impl/fake/units.py
+++ b/pubtools/pulplib/_impl/fake/units.py
@@ -38,6 +38,16 @@ def make_units(type_id, unit_key, unit_metadata, content, repo_id):
     if type_id == "modulemd":
         return make_module_units(content, repo_id)
 
+    # Comps-related types are accepted, but we do not actually process
+    # them into units.
+    if type_id in (
+        "package_group",
+        "package_langpacks",
+        "package_category",
+        "package_environment",
+    ):
+        return []
+
     # It should not be possible to get here via public API.
     #
     # If you see this message, you're probably halfway through implementing

--- a/tests/comps/test_comps_parse.py
+++ b/tests/comps/test_comps_parse.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from pubtools.pulplib._impl.comps import units_for_xml
+
+
+def test_can_parse_units(data_path):
+    """units_for_xml parses typical comps.xml data correctly."""
+
+    xml_path = os.path.join(data_path, "sample-comps.xml")
+
+    with open(xml_path, "rb") as f:
+        units = units_for_xml(f)
+
+    # Simply compare the returned value against expected.
+    # Note, we are comparing elements one by one here to make it a bit
+    # easier to deal with failures (failure message will be quite large
+    # if entire list is compared at once).
+
+    assert len(units) == 7
+
+    assert units[0] == {
+        "_content_type_id": "package_group",
+        "conditional_package_names": [["blender", "something-required-by-blender"]],
+        "default": False,
+        "default_package_names": ["admesh"],
+        "description": "3D printing software",
+        "id": "3d-printing",
+        "name": "3D Printing",
+        "translated_description": {
+            "af": "3D-druksagteware",
+            "bg": u"Софтуер за 3D печатане",
+        },
+        "translated_name": {"af": "3D-drukwerk", "bg": u"3D Печатане"},
+        "user_visible": True,
+    }
+
+    assert units[1] == {
+        "_content_type_id": "package_group",
+        "id": "admin-tools",
+        "name": "Administration Tools",
+        "translated_name": {"af": "Administrasienutsgoed", "am": u"የአስተዳደሩ መሣሪያዎች"},
+        "description": "This group is a collection of graphical administration tools for the system, such as for managing user accounts and configuring system hardware.",
+        "translated_description": {
+            "sr": u"Ова група је скуп графичких системских административних алатки, нпр. за управљање корисничким налозима и подешавање хардвера у систему.",
+            "sr@Latn": u"Ova grupa je skup grafičkih sistemskih administrativnih alatki, npr. za upravljanje korisničkim nalozima i podešavanje hardvera u sistemu.",
+        },
+        "default": False,
+        "user_visible": True,
+        "mandatory_package_names": ["abrt-desktop", "gnome-disk-utility"],
+    }
+
+    assert units[2] == {
+        "_content_type_id": "package_category",
+        "id": "kde-desktop-environment",
+        "name": "KDE Desktop",
+        "translated_name": {"af": "KDE-werkskerm", "as": u"KDE ডেস্কটপ"},
+        "description": "The KDE SC includes the KDE Plasma Desktop, a highly-configurable graphical user interface which includes a panel, desktop, system icons and desktop widgets, and many powerful KDE applications.",
+        "translated_description": {
+            "bn_IN": u"KDE SC-র মধ্যে রয়েছে KDE Plasma ডেস্কটপ। অতিমাত্রায় কনফিগার করার যোগ্য এই ইউজার ইন্টারফেসের মধ্যে রয়েছে একটি প্যানেল, ডেস্কটপ, সিস্টেমের বিভিন্ন আইকন ও ডেস্কটপ উইজেট ও বিভিন্ন উন্নত ক্ষমতাবিশিষ্ট KDE-র অন্যান্য অনেকগুলি অ্যাপ্লিকেশন।",
+            "zh_TW": u"KDE SC 所包含的 KDE Plasma 桌面是個功能強大的圖形使用者介面，它含有面板、桌面、系統圖示與桌面元件，以及許多強大的 KDE 應用軟體。",
+        },
+        "display_order": 10,
+        "packagegroupids": ["kde-office", "kde-telepathy"],
+    }
+
+    assert units[3] == {
+        "_content_type_id": "package_category",
+        "id": "xfce-desktop-environment",
+        "name": "Xfce Desktop",
+        "translated_name": {"uk": u"Графічне середовище Xfce", "zh_CN": u"Xfce 桌面环境"},
+        "description": "A lightweight desktop environment that works well on low end machines.",
+        "translated_description": {
+            "as": u"এটা লঘুভাৰৰ ডেষ্কট'প পৰিবেশ যি নিম্ন বিন্যাসৰ যন্ত্ৰত ভালকৈ কাম কৰি ।",
+            "ast": u"Un entornu d'escritoriu llixeru que furrula bien en máquines pequeñes.",
+        },
+        "display_order": 15,
+        "packagegroupids": ["xfce-apps", "xfce-desktop"],
+    }
+
+    assert units[4] == {
+        "_content_type_id": "package_environment",
+        "id": "basic-desktop-environment",
+        "name": "Basic Desktop",
+        "translated_name": {
+            "af": "Basiese werkskerm",
+            "bg": u"Основен работен плот",
+            "ca": u"Escriptori bàsic",
+        },
+        "description": "X Window System with a choice of window manager.",
+        "translated_description": {
+            "af": u"X Window-stelsel met ’n keuse van vensterbestuurder.",
+            "bg": u"X Window система с избор на мениджър на прозорци.",
+        },
+        "display_order": None,
+        "group_ids": ["networkmanager-submodules", "standard"],
+        "options": [{"default": True, "group": "xmonad"}, {"group": "xmonad-mate"}],
+    }
+
+    assert units[5] == {
+        "_content_type_id": "package_environment",
+        "id": "cinnamon-desktop-environment",
+        "name": "Cinnamon Desktop",
+        "translated_name": {"en_GB": "Cinnamon Desktop", "fr": "Bureau Cinnamon"},
+        "translated_description": {
+            "ca": u"Cinnamon proporciona un escriptori amb un disseny tradicional, funcionalitats avançades, facilitat d'ús, potent i flexible.",
+            "es": u"Cinnamon proporciona un entorno de escritorio tradicional, con características avanzadas, fácil de usar, potente y flexible.",
+        },
+        "display_order": 22,
+        "group_ids": ["input-methods", "multimedia"],
+        "options": [{"group": "libreoffice"}],
+    }
+
+    assert units[6] == {
+        "_content_type_id": "package_langpacks",
+        "matches": [
+            {"install": "stardict-dic-%s", "name": "stardict"},
+            {"install": "tagainijisho-dic-%s", "name": "tagainijisho-common"},
+            {"install": "tesseract-langpack-%s", "name": "tesseract"},
+            {"install": "tkgate-%s", "name": "tkgate"},
+        ],
+    }

--- a/tests/comps/test_comps_parse_edgecase.py
+++ b/tests/comps/test_comps_parse_edgecase.py
@@ -1,0 +1,37 @@
+from io import BytesIO
+from xml.parsers import expat
+
+import pytest
+
+from pubtools.pulplib._impl.comps import units_for_xml
+
+
+def test_can_parse_empty_root():
+    """units_for_xml parses an empty <comps/> document OK."""
+
+    for doc in (b"<comps/>", b"<comps></comps>"):
+        buf = BytesIO(doc)
+
+        # It should parse OK
+        units = units_for_xml(buf)
+
+        # It should be empty
+        assert units == []
+
+
+def test_empty_error():
+    """units_for_xml raises on completely empty input."""
+
+    buf = BytesIO(b"")
+
+    with pytest.raises(expat.ExpatError):
+        units_for_xml(buf)
+
+
+def test_unclosed_error():
+    """units_for_xml raises on document with unclosed tag."""
+
+    buf = BytesIO(b"<comps><group></comps>")
+
+    with pytest.raises(expat.ExpatError):
+        units_for_xml(buf)

--- a/tests/data/sample-comps.xml
+++ b/tests/data/sample-comps.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE comps
+  PUBLIC '-//Red Hat, Inc.//DTD Comps info//EN'
+  'comps.dtd'>
+
+<!--
+  A comps file for testing.
+
+  This was originally taken from Fedora, then tweaked by:
+  - trimming the size significantly so there are only a few of each kind of
+    element
+  - adding some edge cases which are rarely triggered with real data
+-->
+
+<comps>
+
+
+  <group>
+    <id>3d-printing</id>
+    <name>3D Printing</name>
+    <name xml:lang="af">3D-drukwerk</name>
+    <name xml:lang="bg">3D Печатане</name>
+    <description>3D printing software</description>
+    <description xml:lang="af">3D-druksagteware</description>
+    <description xml:lang="bg">Софтуер за 3D печатане</description>
+    <default>false</default>
+    <uservisible>true</uservisible>
+    <packagelist>
+      <packagereq type="default">admesh</packagereq>
+      <!-- tweaked: made the below conditional -->
+      <packagereq type="conditional" requires="something-required-by-blender">blender</packagereq>
+    </packagelist>
+  </group>
+  <group>
+    <id>admin-tools</id>
+    <name>Administration Tools</name>
+    <name xml:lang="af">Administrasienutsgoed</name>
+    <name xml:lang="am">የአስተዳደሩ መሣሪያዎች</name>
+    <description>This group is a collection of graphical administration tools for the system, such as for managing user accounts and configuring system hardware.</description>
+    <description xml:lang="sr">Ова група је скуп графичких системских административних алатки, нпр. за управљање корисничким налозима и подешавање хардвера у систему.</description>
+    <description xml:lang="sr@Latn">Ova grupa je skup grafičkih sistemskih administrativnih alatki, npr. za upravljanje korisničkim nalozima i podešavanje hardvera u sistemu.</description>
+    <default>false</default>
+    <uservisible>true</uservisible>
+    <packagelist>
+      <packagereq type="mandatory">abrt-desktop</packagereq>
+      <packagereq type="mandatory">gnome-disk-utility</packagereq>
+    </packagelist>
+  </group>
+
+
+  <category>
+    <id>kde-desktop-environment</id>
+    <name>KDE Desktop</name>
+    <name xml:lang="af">KDE-werkskerm</name>
+    <name xml:lang="as">KDE ডেস্কটপ</name>
+    <!-- tweaked: mixed some CDATA into the description -->
+    <description>The KDE SC includes the <![CDATA[KDE Plasma Desktop]]>, a highly-configurable graphical user interface which includes a panel, desktop, system icons and desktop widgets, and many powerful KDE applications.</description>
+    <description xml:lang="bn_IN">KDE SC-র মধ্যে রয়েছে KDE Plasma ডেস্কটপ। অতিমাত্রায় কনফিগার করার যোগ্য এই ইউজার ইন্টারফেসের মধ্যে রয়েছে একটি প্যানেল, ডেস্কটপ, সিস্টেমের বিভিন্ন আইকন ও ডেস্কটপ উইজেট ও বিভিন্ন উন্নত ক্ষমতাবিশিষ্ট KDE-র অন্যান্য অনেকগুলি অ্যাপ্লিকেশন।</description>
+    <description xml:lang="zh_TW">KDE SC 所包含的 KDE Plasma 桌面是個功能強大的圖形使用者介面，它含有面板、桌面、系統圖示與桌面元件，以及許多強大的 KDE 應用軟體。</description>
+    <display_order>10</display_order>
+    <grouplist>
+      <groupid>kde-office</groupid>
+      <groupid>kde-telepathy</groupid>
+    </grouplist>
+  </category>
+  <category>
+    <id>xfce-desktop-environment</id>
+    <name>Xfce Desktop</name>
+    <name xml:lang="uk">Графічне середовище Xfce</name>
+    <name xml:lang="zh_CN">Xfce 桌面环境</name>
+    <description>A lightweight desktop environment that works well on low end machines.</description>
+    <description xml:lang="as">এটা লঘুভাৰৰ ডেষ্কট'প পৰিবেশ যি নিম্ন বিন্যাসৰ যন্ত্ৰত ভালকৈ কাম কৰি ।</description>
+    <description xml:lang="ast">Un entornu d'escritoriu llixeru que furrula bien en máquines pequeñes.</description>
+    <display_order>15</display_order>
+    <grouplist>
+      <groupid>xfce-apps</groupid>
+      <groupid>xfce-desktop</groupid>
+    </grouplist>
+  </category>
+
+
+  <environment>
+    <id>basic-desktop-environment</id>
+    <name>Basic Desktop</name>
+    <name xml:lang="af">Basiese werkskerm</name>
+    <name xml:lang="bg">Основен работен плот</name>
+    <name xml:lang="ca">Escriptori bàsic</name>
+    <description>X Window System with a choice of window manager.</description>
+    <description xml:lang="af">X Window-stelsel met ’n keuse van vensterbestuurder.</description>
+    <description xml:lang="bg">X Window система с избор на мениджър на прозорци.</description>
+    <display_order><!-- tweaked: try empty display order --></display_order>
+    <grouplist>
+      <groupid>networkmanager-submodules</groupid>
+      <groupid>standard</groupid>
+    </grouplist>
+    <optionlist>
+      <!-- tweaked: added default -->
+      <groupid default="true">xmonad</groupid>
+      <groupid>xmonad-mate</groupid>
+    </optionlist>
+  </environment>
+  <environment>
+    <id>cinnamon-desktop-environment</id>
+    <name>Cinnamon Desktop</name>
+    <name xml:lang="en_GB">Cinnamon Desktop</name>
+    <name xml:lang="fr">Bureau Cinnamon</name>
+    <description xml:lang="ca">Cinnamon proporciona un escriptori amb un disseny tradicional, funcionalitats avançades, facilitat d'ús, potent i flexible.</description>
+    <description xml:lang="es">Cinnamon proporciona un entorno de escritorio tradicional, con características avanzadas, fácil de usar, potente y flexible.</description>
+    <display_order>22</display_order>
+    <grouplist>
+      <groupid>input-methods</groupid>
+      <groupid>multimedia</groupid>
+    </grouplist>
+    <optionlist>
+      <groupid>libreoffice</groupid>
+    </optionlist>
+  </environment>
+
+  <langpacks>
+    <match install="stardict-dic-%s" name="stardict"/>
+    <match install="tagainijisho-dic-%s" name="tagainijisho-common"/>
+    <match install="tesseract-langpack-%s" name="tesseract"/>
+    <match install="tkgate-%s" name="tkgate"/>
+  </langpacks>
+</comps>

--- a/tests/fake/test_fake_upload_comps.py
+++ b/tests/fake/test_fake_upload_comps.py
@@ -1,0 +1,55 @@
+import os
+from io import BytesIO
+
+from xml.parsers.expat import ExpatError
+
+import pytest
+
+from pubtools.pulplib import FakeController, YumRepository
+
+
+def test_can_upload_comps(data_path):
+    """repo.upload_comps_xml() succeeds with fake client."""
+
+    xml_path = os.path.join(data_path, "sample-comps.xml")
+
+    controller = FakeController()
+
+    controller.insert_repository(YumRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    upload_f = repo1.upload_comps_xml(xml_path)
+
+    # Upload should complete successfully.
+    tasks = upload_f.result()
+
+    # At least one task.
+    assert tasks
+
+    # Every task should have succeeded.
+    for t in tasks:
+        assert t.succeeded
+
+    # If I now search for all content...
+    units_all = list(client.search_content())
+
+    # There should still be nothing, as the fake does not actually store
+    # and reproduce comps-related units.
+    assert units_all == []
+
+
+def test_upload_comps_error():
+    """repo.upload_comps_xml() raises with fake client when given invalid input."""
+    xml = BytesIO(b"Oops not valid")
+
+    controller = FakeController()
+
+    controller.insert_repository(YumRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    with pytest.raises(ExpatError):
+        repo1.upload_comps_xml(xml)

--- a/tests/repository/test_upload_comps.py
+++ b/tests/repository/test_upload_comps.py
@@ -1,0 +1,245 @@
+from io import BytesIO
+from xml.parsers.expat import ExpatError
+
+import pytest
+
+from pubtools.pulplib import YumRepository
+
+
+def test_upload_comps_xml(client, requests_mocker):
+    """A client can upload expected units from within a comps.xml."""
+
+    repo_id = "repo1"
+    repo = YumRepository(id=repo_id)
+    repo.__dict__["_client"] = client
+
+    # Some XML to upload.
+    # This is fairly minimal as this test focuses on upload functionality.
+    # There are other tests exercising the XML parser more thoroughly.
+    xml = BytesIO(
+        b"""
+        <comps>
+            <group>
+                <id>3d-printing</id>
+                <name>3D Printing</name>
+                <name xml:lang="af">3D-drukwerk</name>
+                <description>3D printing software</description>
+                <packagelist>
+                    <packagereq type="default">admesh</packagereq>
+                    <packagereq>blender</packagereq>
+                </packagelist>
+            </group>
+
+            <category>
+                <id>kde-desktop-environment</id>
+                <name>KDE Desktop</name>
+                <display_order>10</display_order>
+                <grouplist>
+                    <groupid>kde-office</groupid>
+                    <groupid>kde-telepathy</groupid>
+                </grouplist>
+            </category>
+
+
+            <environment>
+                <id>basic-desktop-environment</id>
+                <name>Basic Desktop</name>
+                <name xml:lang="af">Basiese werkskerm</name>
+                <description>X Window System with a choice of window manager.</description>
+                <grouplist>
+                    <groupid>networkmanager-submodules</groupid>
+                    <groupid>standard</groupid>
+                </grouplist>
+                <optionlist>
+                    <groupid default="true">xmonad</groupid>
+                    <groupid>xmonad-mate</groupid>
+                </optionlist>
+            </environment>
+
+            <langpacks>
+                <match install="stardict-dic-%s" name="stardict"/>
+                <match install="tkgate-%s" name="tkgate"/>
+            </langpacks>
+        </comps>
+    """
+    )
+
+    # Set up the requests it'll do:
+    #
+    # It should unassociate previous units
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/repo1/actions/unassociate/",
+        json={"spawned_tasks": [{"task_id": "remove-task"}]},
+    )
+
+    # It'll search for the status of tasks.
+    # Note: to avoid an overly complex mock we just let every task search return all
+    # tasks rather than differentiating between remove and upload tasks
+    upload_count = 4
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        json=[{"task_id": "remove-task", "state": "finished"}]
+        + [
+            {"task_id": "upload-task-%d" % i, "state": "finished"}
+            for i in range(0, upload_count)
+        ],
+    )
+
+    # It will request various uploads
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/content/uploads/",
+        [{"json": {"upload_id": "upload-%d" % i}} for i in range(0, upload_count)],
+    )
+
+    # It'll do an import against the uploads
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/repo1/actions/import_upload/",
+        [
+            {"json": {"spawned_tasks": [{"task_id": "upload-task-%d" % i}]}}
+            for i in range(0, upload_count)
+        ],
+    )
+
+    # It'll clean up the uploads
+    for i in range(0, upload_count):
+        requests_mocker.delete(
+            "https://pulp.example.com/pulp/api/v2/content/uploads/upload-%d/" % i
+        )
+
+    # Mocker setup is complete.
+
+    # It should start the upload OK
+    upload_f = repo.upload_comps_xml(xml)
+
+    # I can await the result
+    tasks = upload_f.result()
+
+    # There should be various tasks returned from the API
+    assert sorted([t.id for t in tasks]) == [
+        "upload-task-0",
+        "upload-task-1",
+        "upload-task-2",
+        "upload-task-3",
+    ]
+
+    # Each task should be successful
+    for t in tasks:
+        assert t.completed
+        assert t.succeeded
+
+    # Gather info on exactly what the client imported
+    imported_units = []
+    for req in requests_mocker.request_history:
+        if req.url.endswith("/import_upload/"):
+            imported_units.append(req.json()["unit_metadata"])
+
+    imported_units.sort(key=lambda u: u["_content_type_id"])
+
+    # Did we import exactly the expected units?
+    assert imported_units == [
+        {
+            "_content_type_id": "package_category",
+            "id": "kde-desktop-environment",
+            "name": "KDE Desktop",
+            "display_order": 10,
+            "packagegroupids": ["kde-office", "kde-telepathy"],
+            "repo_id": "repo1",
+        },
+        {
+            "_content_type_id": "package_environment",
+            "id": "basic-desktop-environment",
+            "name": "Basic Desktop",
+            "translated_name": {"af": "Basiese werkskerm"},
+            "description": "X Window System with a choice of window manager.",
+            "group_ids": ["networkmanager-submodules", "standard"],
+            "options": [{"group": "xmonad", "default": True}, {"group": "xmonad-mate"}],
+            "repo_id": "repo1",
+        },
+        {
+            "_content_type_id": "package_group",
+            "id": "3d-printing",
+            "name": "3D Printing",
+            "translated_name": {"af": "3D-drukwerk"},
+            "description": "3D printing software",
+            "default_package_names": ["admesh"],
+            "mandatory_package_names": ["blender"],
+            "repo_id": "repo1",
+        },
+        {
+            "_content_type_id": "package_langpacks",
+            "matches": [
+                {"install": "stardict-dic-%s", "name": "stardict"},
+                {"install": "tkgate-%s", "name": "tkgate"},
+            ],
+            "repo_id": "repo1",
+        },
+    ]
+
+
+def test_upload_empty_comps_xml(client, requests_mocker):
+    """A client can upload an empty comps.xml, which merely removes existing units."""
+
+    repo_id = "repo1"
+    repo = YumRepository(id=repo_id)
+    repo.__dict__["_client"] = client
+
+    xml = BytesIO(b"<comps/>")
+
+    # Set up the requests it'll do:
+    #
+    # It should unassociate previous units
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/repo1/actions/unassociate/",
+        json={"spawned_tasks": [{"task_id": "remove-task"}]},
+    )
+
+    # It'll search for the status of tasks.
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        json=[{"task_id": "remove-task", "state": "finished"}],
+    )
+
+    # And... that's it.
+
+    # It should start the upload OK
+    upload_f = repo.upload_comps_xml(xml)
+
+    # I can await the result
+    tasks = upload_f.result()
+
+    # It should just return the removal task
+    assert [t.id for t in tasks] == ["remove-task"]
+    assert tasks[0].completed
+    assert tasks[0].succeeded
+
+    # Check exactly the removed types
+    assert requests_mocker.request_history[0].json() == {
+        "criteria": {
+            "type_ids": [
+                "package_group",
+                "package_category",
+                "package_environment",
+                "package_langpacks",
+            ]
+        }
+    }
+
+
+def test_bad_comps_xml(client, requests_mocker, tmpdir):
+    """A client requested to upload an invalid comps.xml will raise immediately
+    without making any requests to Pulp."""
+
+    repo_id = "repo1"
+    repo = YumRepository(id=repo_id)
+    repo.__dict__["_client"] = client
+
+    comps_xml = tmpdir.join("comps.xml")
+    comps_xml.write(b"Oops not valid comps")
+
+    # It should raise
+    with pytest.raises(ExpatError):
+        repo.upload_comps_xml(str(comps_xml))
+
+    # As we did not register anything in requests_mocker, we've already
+    # implicitly tested that no requests happened. But just to be clear...
+    assert not requests_mocker.request_history


### PR DESCRIPTION
Introduce YumRepository.upload_comps_xml, which does:

- parse a given comps.xml file into pulp unit representation
- remove existing comps-related units from target repo
- upload new units

There are a couple of design decisions to be explained:

### Server vs client-side XML parsing

The approach used here is compatible with the behavior used in our
toolchain for the past several years, which is to parse comps.xml
client-side and then upload individual units.

However, Pulp does actually support server-side parsing of comps.xml
since early 2016. Support for this was added at "our" request, but
changes were never made to the tooling to start using that feature.

I did investigate moving to server-side parsing of comps.xml but decided
against it because:

- By inspection I was able to find two bugs which would have to be fixed
  before using it. As the feature may have been unused in the years
  since it was implemented, I feel there is a risk of more issues.

- Since the process can't be handled atomically (even if Pulp is doing
  the parsing), we should validate the XML before upload, otherwise an
  attempt to upload an invalid comps.xml could leave the repo in a
  corrupt state. Client-side parsing into Pulp units ensure we only
  proceed with any writes on Pulp if we're confident we've got data that
  Pulp will be able to handle.

### Lack of model units

Unlike with most other data we can upload, no corresponding *Unit
classes were added for the comps-related units (e.g. PackageGroupUnit).
This means that comps.xml data is effectively write-only for this
library right now.

This was done because there is no specific reason to add them and some
potential downsides to doing so. The publishing tools right now treat
comps.xml as an opaque blob; nothing other than the Pulp upload code
looks "inside" of comps.xml, or looks at Pulp units and makes decisions
based on their content.

This seems like a good thing, as it ensures all handling of comps.xml
remains simple; let's not make the Pulp units too easy to access, so
we can hopefully keep it this way.

If the units turn out to be needed, they can be added later with no
backwards-incompatible changes required.