### PR TITLE
Add parameters to perform basic authentication with a sync source

### DIFF
--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -112,6 +112,14 @@ class SyncOptions(object):
     """A string representing the password that should be used to authenticate with the proxy server
     """
 
+    basic_auth_username = pulp_attrib(default=None, type=str)
+    """Username to authenticate with source which supports basic authentication.
+    """
+
+    basic_auth_password = pulp_attrib(default=None, type=str)
+    """Password to authenticate with source which supports basic authentication.
+    """
+
 
 @attr.s(kw_only=True, frozen=True)
 class Repository(PulpObject, Deletable):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.17.0",
+    version="2.18.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",


### PR DESCRIPTION
According to docs[1][2], syncing from private container repositories
should be supported by specifying basic auth credentials.

[1] https://docs.pulpproject.org/en/2.11/plugins/pulp_docker/user-guide/release-notes/2.1.x.html
[2] https://docs.pulpproject.org/en/2.11/user-guide/content-sources.html

This change will be necessary for a specific Dynamo rollback edge-case, where we'll want to directly sync certain tags from Quay back to Pulp

Refers to CLOUDDST-10252