### PR TITLE
Fix missing update to repository_memberships in fake copy_content

### DIFF
--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -225,6 +225,13 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         to_id = to_repository.id
 
         found = list(from_repository.search_content(criteria).result())
+
+        # Units are being copied to this repo, so that value obviously must appear
+        # in repository_memberships from now on.
+        found = [attr.evolve(unit, repository_memberships=[to_id]) for unit in found]
+
+        # Now put the found units into the destination repo.
+        # Any kind of merging or replacing of units is handled within this step.
         self._insert_repo_units(to_id, found)
 
         # Arbitrarily limit the number of units included per task. The point is

--- a/tests/fake/test_fake_copy_content.py
+++ b/tests/fake/test_fake_copy_content.py
@@ -58,7 +58,12 @@ def test_copy_content_all(controller):
     src_units = [
         ErratumUnit(id="RHSA-1111:22", summary="Fixes bad things"),
         ModulemdUnit(
-            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+            name="module1",
+            stream="s1",
+            version=1234,
+            context="a1b2",
+            arch="x86_64",
+            repository_memberships=["repoA", "repoB"],
         ),
         RpmUnit(
             name="bash",
@@ -111,7 +116,37 @@ def test_copy_content_all(controller):
 
     # The copy should also impact subsequent content searches.
     dest_units = list(dest.search_content())
-    assert src_units == sorted(dest_units, key=repr)
+
+    # The units we get from the search are not *precisely* the same as src_units,
+    # because repository_memberships has been updated.
+    assert sorted(dest_units, key=repr) == [
+        ErratumUnit(
+            id="RHSA-1111:22",
+            summary="Fixes bad things",
+            content_type_id="erratum",
+            repository_memberships=["dest-repo"],
+        ),
+        ModulemdUnit(
+            name="module1",
+            stream="s1",
+            version=1234,
+            context="a1b2",
+            arch="x86_64",
+            content_type_id="modulemd",
+            repository_memberships=["dest-repo", "repoA", "repoB"],
+        ),
+        RpmUnit(
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+            epoch="0",
+            signing_key="a1b2c3",
+            filename="bash-4.0-1.x86_64.rpm",
+            content_type_id="rpm",
+            repository_memberships=["dest-repo"],
+        ),
+    ]
 
 
 def test_copy_content_with_criteria(controller):
@@ -155,6 +190,20 @@ def test_copy_content_with_criteria(controller):
     # The copy should also impact subsequent content searches.
     dest_units = list(dest.search_content())
     assert sorted(dest_units, key=repr) == [
-        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64", epoch="0"),
-        RpmUnit(name="bash", version="4.1", release="3", arch="x86_64", epoch="0"),
+        RpmUnit(
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+            epoch="0",
+            repository_memberships=["dest-repo"],
+        ),
+        RpmUnit(
+            name="bash",
+            version="4.1",
+            release="3",
+            arch="x86_64",
+            epoch="0",
+            repository_memberships=["dest-repo"],
+        ),
     ]


### PR DESCRIPTION
When using copy_content on the fake client it was not ensured that
repository_memberships would be updated to include the destination repo
ID. Add the missing logic to do this.