### PR TITLE
Add some missing pulp_user_metadata fields on files, RPMs

### DIFF
--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -30,7 +30,13 @@ def null_convert(value):
 
 
 def read_timestamp(value):
-    return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    try:
+        return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        # irritatingly (probably a bug), some values were missing the "Z"
+        # technically meaning we don't know the timezone.
+        # So we try parsing again without it and we just assume it's UTC.
+        return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
 
 def write_timestamp(value):

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -1,8 +1,11 @@
+import datetime
+
 from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
 from ..convert import frozenlist_or_none_sorted_converter
+from ..validate import optional_str, instance_of
 
 
 @unit_type("iso")
@@ -30,6 +33,46 @@ class FileUnit(Unit):
         unit_key=True,
     )
     """SHA256 checksum of this file, as a hex string."""
+
+    description = pulp_attrib(
+        type=str,
+        pulp_field="pulp_user_metadata.description",
+        default=None,
+        validator=optional_str,
+    )
+    """A user-oriented terse description of this file.
+
+    .. versionadded:: 2.20.0
+    """
+
+    cdn_path = pulp_attrib(
+        type=str,
+        pulp_field="pulp_user_metadata.cdn_path",
+        default=None,
+        validator=optional_str,
+    )
+    """A path, relative to the CDN root, from which this file can be downloaded
+    once published.
+
+    This path will not point to any specific repository. However, the file must
+    have been published via at least one repository before this path can be
+    accessed.
+
+    .. versionadded:: 2.20.0
+    """
+
+    cdn_published = pulp_attrib(
+        type=datetime.datetime,
+        pulp_field="pulp_user_metadata.cdn_published",
+        default=None,
+        validator=instance_of((datetime.datetime, type(None))),
+    )
+    """Approximate :class:`~datetime.datetime` in UTC at which this file first
+    became available at ``cdn_path``, or ``None`` if this information is
+    unavailable.
+
+    .. versionadded:: 2.20.0
+    """
 
     content_type_id = pulp_attrib(
         default="iso", type=str, pulp_field="_content_type_id"

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -1,9 +1,12 @@
+import datetime
+
 from pubtools.pulplib._impl.model.validate import optional_list_of
 from .base import Unit, unit_type, schemaless_init
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
 from ..convert import frozenlist_or_none_converter, frozenlist_or_none_sorted_converter
+from ..validate import optional_str, instance_of
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -145,6 +148,35 @@ class RpmUnit(Unit):
     content_type_id = pulp_attrib(
         default="rpm", type=str, pulp_field="_content_type_id"
     )
+
+    cdn_path = pulp_attrib(
+        type=str,
+        pulp_field="pulp_user_metadata.cdn_path",
+        default=None,
+        validator=optional_str,
+    )
+    """A path, relative to the CDN root, from which this RPM can be downloaded
+    once published.
+
+    This path will not point to any specific repository. However, the RPM must
+    have been published via at least one repository before this path can be
+    accessed.
+
+    .. versionadded:: 2.20.0
+    """
+
+    cdn_published = pulp_attrib(
+        type=datetime.datetime,
+        pulp_field="pulp_user_metadata.cdn_published",
+        default=None,
+        validator=instance_of((datetime.datetime, type(None))),
+    )
+    """Approximate :class:`~datetime.datetime` in UTC at which this RPM first
+    became available at ``cdn_path``, or ``None`` if this information is
+    unavailable.
+
+    .. versionadded:: 2.20.0
+    """
 
     repository_memberships = pulp_attrib(
         default=None,

--- a/tests/unit/test_file_unit.py
+++ b/tests/unit/test_file_unit.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pubtools.pulplib import FileUnit
 
 
@@ -38,4 +40,32 @@ def test_zero_size():
         size=0,
         sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         content_type_id="iso",
+    )
+
+
+def test_user_metadata_fields():
+    """FileUnit.from_data parses pulp_user_metadata fields OK"""
+
+    loaded = FileUnit.from_data(
+        {
+            "_content_type_id": "iso",
+            "name": "my-file",
+            "checksum": "49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+            "size": 123,
+            "pulp_user_metadata": {
+                "description": "The best file I ever saw",
+                "cdn_path": "/some/path/to/my-file",
+                "cdn_published": "2021-04-01T01:08:26",
+            },
+        }
+    )
+
+    assert loaded == FileUnit(
+        path="my-file",
+        size=123,
+        sha256sum="49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+        content_type_id="iso",
+        description="The best file I ever saw",
+        cdn_path="/some/path/to/my-file",
+        cdn_published=datetime.datetime(2021, 4, 1, 1, 8, 26),
     )

--- a/tests/unit/test_rpm_unit.py
+++ b/tests/unit/test_rpm_unit.py
@@ -1,0 +1,35 @@
+import datetime
+
+from pubtools.pulplib import RpmUnit
+
+
+def test_user_metadata_fields():
+    """RpmUnit.from_data parses pulp_user_metadata fields OK"""
+
+    loaded = RpmUnit.from_data(
+        {
+            "_content_type_id": "rpm",
+            "name": "bash",
+            "epoch": "0",
+            "filename": "bash-x86_64.rpm",
+            "version": "4.0",
+            "release": "1",
+            "arch": "x86_64",
+            "pulp_user_metadata": {
+                "cdn_path": "/some/path/to/my.rpm",
+                "cdn_published": "2021-04-01T01:08:26",
+            },
+        }
+    )
+
+    assert loaded == RpmUnit(
+        name="bash",
+        epoch="0",
+        filename="bash-x86_64.rpm",
+        version="4.0",
+        release="1",
+        arch="x86_64",
+        content_type_id="rpm",
+        cdn_path="/some/path/to/my.rpm",
+        cdn_published=datetime.datetime(2021, 4, 1, 1, 8, 26),
+    )


### PR DESCRIPTION
This adds some fields onto models which will be needed during push but
haven't been included previously.

Note that pulplib will require some updates to support setting these
fields as well, but this is not included here.