### PR TITLE
Introduce Client.search_task to search for Pulp tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Added `Client.search_task` for searching tasks.
 
 ## [2.17.0] - 2021-10-27
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -355,7 +355,7 @@ class Client(object):
                 Each page will contain a collection of
                 :class:`~pubtools.pulplib.Task` objects.
 
-        .. versionadded:: 2.18.0
+        .. versionadded:: 2.19.0
         """
         return self._search(Task, "tasks", criteria=criteria)
 

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -13,7 +13,7 @@ from six.moves import StringIO
 
 from ..page import Page
 from ..criteria import Criteria
-from ..model import Repository, MaintenanceReport, Distributor, Unit
+from ..model import Repository, MaintenanceReport, Distributor, Unit, Task
 from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
@@ -339,6 +339,25 @@ class Client(object):
         .. versionadded:: 2.1.0
         """
         return self._search(Distributor, "distributors", criteria=criteria)
+
+    def search_task(self, criteria=None):
+        """Search the tasks matching the given criteria.
+
+        Args:
+            criteria (:class:`~pubtools.pulplib.Criteria`)
+                A criteria object used for this search.
+                If None, search for all tasks.
+
+        Returns:
+            Future[:class:`~pubtools.pulplib.Page`]
+                A future representing the first page of results.
+
+                Each page will contain a collection of
+                :class:`~pubtools.pulplib.Task` objects.
+
+        .. versionadded:: 2.18.0
+        """
+        return self._search(Task, "tasks", criteria=criteria)
 
     def _search(
         self,

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -79,6 +79,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         self._upload_history = []
         self._uploads_pending = {}
         self._sync_history = []
+        self._tasks = []
         self._maintenance_report = None
         self._type_ids = self._DEFAULT_TYPE_IDS[:]
         self._lock = threading.RLock()
@@ -276,6 +277,23 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         random.shuffle(distributors)
         return self._prepare_pages(distributors)
+
+    def search_task(self, criteria=None):
+        self._ensure_alive()
+        tasks = []
+
+        criteria = criteria or Criteria.true()
+        search_for_criteria(criteria)
+
+        try:
+            for task in self._tasks:
+                if match_object(criteria, task):
+                    tasks.append(task)
+        except Exception as ex:  # pylint: disable=broad-except
+            return f_return_error(ex)
+
+        random.shuffle(tasks)
+        return self._prepare_pages(tasks)
 
     def _search_repo_units(self, repo_id, criteria):
         criteria = criteria or Criteria.true()

--- a/pubtools/pulplib/_impl/fake/controller.py
+++ b/pubtools/pulplib/_impl/fake/controller.py
@@ -158,3 +158,17 @@ class FakeController(object):
         )
 
         return self.client._upload_history[:]
+
+    @property
+    def tasks(self):
+        """The list of existing tasks in the fake client."""
+        return self.client._tasks[:]
+
+    def insert_task(self, task):
+        """Add a task to the set of existing tasks in the fake client.
+
+        Args:
+            task (:class:`~pubtools.pulplib.Task`)
+                A task object to insert.
+        """
+        self.client._tasks.append(task)

--- a/pubtools/pulplib/_impl/fake/match.py
+++ b/pubtools/pulplib/_impl/fake/match.py
@@ -97,6 +97,12 @@ def match_field(criteria, obj):
 @visit(EqMatcher)
 def match_field_eq(matcher, field, obj):
     value = get_field(field, obj)
+    # Pulp/mongo query is defined the same when matching
+    # with a list or object/string field e.g.
+    # {"foo": "bar"} will match if "foo": "bar" or
+    # "foo": ["bar", "bas"]
+    if isinstance(value, list) and not isinstance(matcher._value, list):
+        return matcher._value in value
     return value == matcher._value
 
 

--- a/tests/fake/test_fake_search.py
+++ b/tests/fake/test_fake_search.py
@@ -2,7 +2,14 @@ import datetime
 
 import pytest
 
-from pubtools.pulplib import FakeController, Repository, Criteria, Matcher, Distributor
+from pubtools.pulplib import (
+    FakeController,
+    Repository,
+    Criteria,
+    Matcher,
+    Distributor,
+    Task,
+)
 
 
 def test_can_search_id():
@@ -430,3 +437,29 @@ def test_search_mapped_field_less_than():
     found = client.search_distributor(crit).result().data
 
     assert found == [dist1]
+
+
+def test_search_task():
+    controller = FakeController()
+
+    task1 = Task(
+        id="task1",
+        completed=True,
+        succeeded=True,
+        tags=[
+            "pulp:repository:repo1",
+            "pulp:action:publish",
+        ],
+    )
+
+    controller.insert_task(task1)
+
+    client = controller.client
+
+    crit = Criteria.with_field("tags", "pulp:action:publish")
+    resp = client.search_task(crit).result().data
+    assert resp == [task1]
+
+    crit2 = Criteria.with_field("id", "task1")
+    resp2 = client.search_task(crit2).result().data
+    assert resp2 == [task1]

--- a/tests/fake/test_fake_search.py
+++ b/tests/fake/test_fake_search.py
@@ -451,8 +451,18 @@ def test_search_task():
             "pulp:action:publish",
         ],
     )
+    task2 = Task(
+        id="task2",
+        completed=True,
+        succeeded=True,
+        tags=[
+            "pulp:repository:repo1",
+            "pulp:action:import_upload",
+        ],
+    )
 
     controller.insert_task(task1)
+    controller.insert_task(task2)
 
     client = controller.client
 
@@ -460,6 +470,6 @@ def test_search_task():
     resp = client.search_task(crit).result().data
     assert resp == [task1]
 
-    crit2 = Criteria.with_field("id", "task1")
+    crit2 = Criteria.with_field("id", "task2")
     resp2 = client.search_task(crit2).result().data
-    assert resp2 == [task1]
+    assert resp2 == [task2]


### PR DESCRIPTION
Client has a new search_task api to search for the pulp tasks.
This returns Task objects matching the criteria.

Added the same api to the fake client as well which returns the
tasks added to the controller that match the criteria.
Modified the match_field_eq i.e. EqMatcher for the fake client
to match the values in the list type fields too. It now matches
if one of the values in the list type field is present.