### PR TITLE
Support setting mutable (pulp_user_metadata) fields

### DIFF
--- a/pubtools/pulplib/_impl/model/common.py
+++ b/pubtools/pulplib/_impl/model/common.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 
 import jsonschema
 import six
@@ -152,6 +153,10 @@ class PulpObject(object):
         if isinstance(value, PulpObject):
             # It's a model object, then delegate to the instance method.
             return value._to_data()
+
+        if isinstance(value, datetime.datetime):
+            # For datetimes, we always use an ISO8601 timestamp format.
+            return value.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         # For anything else, we assume it can be used as-is.
         # strs and ints for example fall into this path.

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -42,6 +42,10 @@ class FileUnit(Unit):
     )
     """A user-oriented terse description of this file.
 
+    This field is **mutable** and may be set by
+    :meth:`~FileRepository.upload_file` or
+    :meth:`~Client.update_content`.
+
     .. versionadded:: 2.20.0
     """
 
@@ -58,6 +62,10 @@ class FileUnit(Unit):
     have been published via at least one repository before this path can be
     accessed.
 
+    This field is **mutable** and may be set by
+    :meth:`~FileRepository.upload_file` or
+    :meth:`~Client.update_content`.
+
     .. versionadded:: 2.20.0
     """
 
@@ -70,6 +78,10 @@ class FileUnit(Unit):
     """Approximate :class:`~datetime.datetime` in UTC at which this file first
     became available at ``cdn_path``, or ``None`` if this information is
     unavailable.
+
+    This field is **mutable** and may be set by
+    :meth:`~FileRepository.upload_file` or
+    :meth:`~Client.update_content`.
 
     .. versionadded:: 2.20.0
     """

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -162,6 +162,10 @@ class RpmUnit(Unit):
     have been published via at least one repository before this path can be
     accessed.
 
+    This field is **mutable** and may be set by
+    :meth:`~YumRepository.upload_rpm` or
+    :meth:`~Client.update_content`.
+
     .. versionadded:: 2.20.0
     """
 
@@ -174,6 +178,10 @@ class RpmUnit(Unit):
     """Approximate :class:`~datetime.datetime` in UTC at which this RPM first
     became available at ``cdn_path``, or ``None`` if this information is
     unavailable.
+
+    This field is **mutable** and may be set by
+    :meth:`~YumRepository.upload_rpm` or
+    :meth:`~Client.update_content`.
 
     .. versionadded:: 2.20.0
     """

--- a/tests/client/test_update_content.py
+++ b/tests/client/test_update_content.py
@@ -1,0 +1,85 @@
+import pytest
+import datetime
+
+from pubtools.pulplib import FileUnit
+
+
+def test_update_no_id(requests_mocker, client):
+    # Try to update something with no ID; it should fail immediately
+    # (no future) as we can't even try to update without an ID.
+    with pytest.raises(ValueError) as excinfo:
+        client.update_content(
+            FileUnit(
+                path="x",
+                size=0,
+                sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+        )
+
+    # It should tell us why
+    assert "unit_id missing on call to update_content()" in str(excinfo.value)
+
+
+def test_can_update_content(requests_mocker, client):
+    requests_mocker.put(
+        "https://pulp.example.com/pulp/api/v2/content/units/iso/some-unit/pulp_user_metadata/",
+        # Note: passing json=None here doesn't work as requests_mocker seems
+        # unable to differentiate between "json should be None" and "no json response
+        # is specified".
+        text="null",
+        headers={"Content-Type": "application/json"},
+    )
+
+    unit = FileUnit(
+        unit_id="some-unit",
+        description="A unit I'm about to update",
+        cdn_published=datetime.datetime(2021, 12, 6, 11, 19, 0),
+        path="x",
+        size=0,
+        sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    )
+
+    update_f = client.update_content(unit)
+
+    # It should succeed.
+    update_f.result()
+
+    # It should have done a single request.
+    assert len(requests_mocker.request_history) == 1
+
+    req = requests_mocker.request_history[0]
+
+    # Should have been a PUT to the appropriate API.
+    assert req.method == "PUT"
+    assert (
+        req.url
+        == "https://pulp.example.com/pulp/api/v2/content/units/iso/some-unit/pulp_user_metadata/"
+    )
+
+    # Should have included all the usermeta fields in request body.
+    assert req.json() == {
+        "cdn_path": None,
+        "cdn_published": "2021-12-06T11:19:00Z",
+        "description": "A unit I'm about to update",
+    }
+
+
+def test_update_content_fails(requests_mocker, client):
+    requests_mocker.put(
+        "https://pulp.example.com/pulp/api/v2/content/units/iso/some-unit/pulp_user_metadata/",
+        status_code=400,
+    )
+
+    unit = FileUnit(
+        unit_id="some-unit",
+        description="A unit I'm about to update",
+        cdn_path="/some/path.txt",
+        path="x",
+        size=0,
+        sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    )
+
+    update_f = client.update_content(unit)
+
+    # It should fail, since the HTTP request failed.
+    assert "400 Client Error" in str(update_f.exception())

--- a/tests/fake/test_fake_update_content.py
+++ b/tests/fake/test_fake_update_content.py
@@ -1,0 +1,98 @@
+import datetime
+import pytest
+import attr
+
+from pubtools.pulplib import FakeController, FileUnit, FileRepository
+
+
+def test_update_no_id():
+    controller = FakeController()
+    client = controller.client
+
+    # Try to update something with no ID; it should fail immediately
+    # (no future) as we can't even try to update without an ID.
+    with pytest.raises(ValueError) as excinfo:
+        client.update_content(
+            FileUnit(
+                path="x",
+                size=0,
+                sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+        )
+
+    # It should tell us why
+    assert "unit_id missing on call to update_content()" in str(excinfo.value)
+
+
+def test_update_nonexistent():
+    controller = FakeController()
+    client = controller.client
+
+    # Try to update something which doesn't exist.
+    update_f = client.update_content(
+        FileUnit(
+            unit_id="this-unit-is-missing",
+            path="x",
+            size=0,
+            sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        )
+    )
+
+    # It should fail, async.
+    assert "unit not found: this-unit-is-missing" in str(update_f.exception())
+
+
+def test_can_update_content(tmpdir):
+    controller = FakeController()
+
+    controller.insert_repository(FileRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    somefile = tmpdir.join("some-file.txt")
+    somefile.write(b"there is some binary data:\x00\x01\x02")
+
+    upload_f = repo1.upload_file(
+        str(somefile), description="My great file", cdn_path="/foo/bar.txt"
+    )
+
+    # The future should resolve successfully
+    tasks = upload_f.result()
+
+    # The task should be successful.
+    assert tasks[0].succeeded
+
+    # File should now be in repo.
+    units_in_repo = list(repo1.search_content())
+    assert len(units_in_repo) == 1
+    unit = units_in_repo[0]
+
+    # Sanity check we got the right thing.
+    assert unit.path == "some-file.txt"
+
+    # Now let's try updating fields.
+    new_unit = attr.evolve(
+        unit,
+        size=1000,
+        description="My greater file",
+        cdn_published=datetime.datetime(2021, 12, 6, 11, 19, 0),
+    )
+
+    update_f = client.update_content(new_unit)
+
+    # It should succeed.
+    update_f.result()
+
+    # Now get the unit again.
+    units_in_repo = list(repo1.search_content())
+    assert len(units_in_repo) == 1
+    unit_after_update = units_in_repo[0]
+
+    # The mutable fields on the unit after update should be as expected:
+    assert unit_after_update.description == "My greater file"
+    assert unit_after_update.cdn_published == datetime.datetime(2021, 12, 6, 11, 19, 0)
+    # This one didn't change since it wasn't evolved
+    assert unit_after_update.cdn_path == "/foo/bar.txt"
+    # This one didn't change (even though we tried) because it's not mutable
+    assert unit_after_update.size == 29

--- a/tests/fake/test_fake_upload_usermeta.py
+++ b/tests/fake/test_fake_upload_usermeta.py
@@ -1,0 +1,94 @@
+import os
+import pytest
+
+from pubtools.pulplib import FakeController, FileRepository, YumRepository
+
+
+def test_upload_file_meta_wrong_fields(tmpdir):
+    controller = FakeController()
+
+    controller.insert_repository(FileRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    somefile = tmpdir.join("some-file.txt")
+    somefile.write(b"there is some binary data:\x00\x01\x02")
+
+    # This should immediately give an error
+    with pytest.raises(ValueError) as excinfo:
+        repo1.upload_file(
+            str(somefile), description="My great file", size=48, other="whatever"
+        )
+
+    # It should give an indication of the problem
+    assert "Not mutable FileUnit field(s): other, size" in str(excinfo.value)
+
+
+def test_can_upload_file_meta(tmpdir):
+    controller = FakeController()
+
+    controller.insert_repository(FileRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    somefile = tmpdir.join("some-file.txt")
+    somefile.write(b"there is some binary data:\x00\x01\x02")
+
+    upload_f = repo1.upload_file(
+        str(somefile), description="My great file", cdn_path="/foo/bar.txt"
+    )
+
+    # The future should resolve successfully
+    tasks = upload_f.result()
+
+    # The task should be successful.
+    assert tasks[0].succeeded
+
+    # File should now be in repo.
+    units_in_repo = list(repo1.search_content())
+    assert len(units_in_repo) == 1
+    unit = units_in_repo[0]
+
+    # Sanity check we got the right thing.
+    assert unit.path == "some-file.txt"
+
+    # Extra fields we passed during upload should be present here.
+    assert unit.description == "My great file"
+    assert unit.cdn_path == "/foo/bar.txt"
+
+
+def test_can_upload_rpm_meta(data_path):
+    rpm_path = os.path.join(data_path, "rpms/walrus-5.21-1.noarch.rpm")
+    controller = FakeController()
+
+    controller.insert_repository(YumRepository(id="repo1"))
+
+    client = controller.client
+    repo1 = client.get_repository("repo1").result()
+
+    to_upload = rpm_path
+
+    upload_f = repo1.upload_rpm(to_upload, cdn_path="/path/to/my-great.rpm")
+
+    # Upload should complete successfully.
+    tasks = upload_f.result()
+
+    # At least one task.
+    assert tasks
+
+    # Every task should have succeeded.
+    for t in tasks:
+        assert t.succeeded
+
+    # RPM should now be in repo.
+    units_in_repo = list(repo1.search_content())
+    assert len(units_in_repo) == 1
+    unit = units_in_repo[0]
+
+    # Sanity check we got the right unit.
+    assert unit.filename == "walrus-5.21-1.noarch.rpm"
+
+    # Extra fields we passed during upload should be present here.
+    assert unit.cdn_path == "/path/to/my-great.rpm"


### PR DESCRIPTION
We need to be able to support setting these fields on files and RPMs.
It is necessary to support setting them both during upload and at other
times, for example:

- cdn_path: this must be set before the unit can be published by
  cdn_distributor.

- cdn_published: this must be set only *after* the unit has been
  published to the CDN.

- description: on iso/file units, it should be possible to change the
  value for existing content without having to re-upload it.

This commit adds support for setting any fields under pulp_user_metadata
either during upload or as a standalone operation. Fields which can be
updated in this way are called out in the docs.