### PR TITLE
Add unit_id field onto unit models

### DIFF
--- a/pubtools/pulplib/_impl/fake/units.py
+++ b/pubtools/pulplib/_impl/fake/units.py
@@ -1,6 +1,9 @@
 import hashlib
 import tempfile
 import logging
+import random
+import threading
+import uuid
 
 import yaml
 import attr
@@ -27,41 +30,193 @@ from ..model.attr import PULP2_UNIT_KEY
 LOG = logging.getLogger("pubtools.pulplib")
 
 
-def make_units(type_id, unit_key, unit_metadata, content, repo_id):
-    # Obtain valid unit(s) representing uploaded 'content'.
+class UnitMaker(object):
+    def __init__(self, seen_unit_ids):
+        self._lock = threading.RLock()
+        self._uuidgen = random.Random()
+        self._uuidgen.seed(0)
+        self._seen_unit_ids = seen_unit_ids
 
-    if type_id == "iso":
-        return [make_iso_unit(unit_key)]
+    def next_unit_id(self):
+        with self._lock:
+            while True:
+                next_raw_id = self._uuidgen.randint(0, 2 ** 128)
+                if next_raw_id not in self._seen_unit_ids:
+                    break
 
-    if type_id == "yum_repo_metadata_file":
-        return [make_yum_repo_metadata_unit(unit_key, unit_metadata)]
+        return str(uuid.UUID(int=next_raw_id))
 
-    if type_id == "rpm":
-        return [make_rpm_unit(content)]
+    def make_units(self, type_id, unit_key, unit_metadata, content, repo_id):
+        # Obtain valid unit(s) representing uploaded 'content'.
 
-    if type_id == "erratum":
-        return [make_erratum_unit(unit_metadata)]
+        if type_id == "iso":
+            return [self.make_iso_unit(unit_key)]
 
-    if type_id == "modulemd":
-        return make_module_units(content, repo_id)
+        if type_id == "yum_repo_metadata_file":
+            return [self.make_yum_repo_metadata_unit(unit_key, unit_metadata)]
 
-    # Comps-related types are accepted, but we do not actually process
-    # them into units.
-    if type_id in (
-        "package_group",
-        "package_langpacks",
-        "package_category",
-        "package_environment",
-    ):
-        return []
+        if type_id == "rpm":
+            return [self.make_rpm_unit(content)]
 
-    # It should not be possible to get here via public API.
-    #
-    # If you see this message, you're probably halfway through implementing
-    # something. Well done, you've found the next place you need to update!
-    raise NotImplementedError(
-        "fake client does not support upload of '%s'" % type_id
-    )  # pragma: no cover
+        if type_id == "erratum":
+            return [self.make_erratum_unit(unit_metadata)]
+
+        if type_id == "modulemd":
+            return self.make_module_units(content, repo_id)
+
+        # Comps-related types are accepted, but we do not actually process
+        # them into units.
+        if type_id in (
+            "package_group",
+            "package_langpacks",
+            "package_category",
+            "package_environment",
+        ):
+            return []
+
+        # It should not be possible to get here via public API.
+        #
+        # If you see this message, you're probably halfway through implementing
+        # something. Well done, you've found the next place you need to update!
+        raise NotImplementedError(
+            "fake client does not support upload of '%s'" % type_id
+        )  # pragma: no cover
+
+    def make_iso_unit(self, unit_key):
+        return FileUnit(
+            unit_id=self.next_unit_id(),
+            path=unit_key["name"],
+            size=unit_key["size"],
+            sha256sum=unit_key["checksum"],
+        )
+
+    def make_yum_repo_metadata_unit(self, unit_key, unit_metadata):
+        # For expected fields in unit_key vs metadata, refer to:
+        # https://github.com/pulp/pulp_rpm/blob/5c5a7dcc058b29d89b3a913d29cfcab41db96686/plugins/pulp_rpm/plugins/importers/yum/upload.py#L246
+        return YumRepoMetadataFileUnit(
+            unit_id=self.next_unit_id(),
+            data_type=unit_key["data_type"],
+            sha256sum=unit_metadata["checksum"],
+        )
+
+    def make_erratum_unit(self, metadata):
+        md = metadata.copy()
+        md["_id"] = self.next_unit_id()
+        md["_content_type_id"] = "erratum"
+        return ErratumUnit.from_data(md)
+
+    def make_rpm_unit(self, content):
+        # Since the native RPM library is used under the hood here,
+        # any old file-like object isn't good enough; it *must* be a real file with
+        # a 'fileno' which can be passed into syscalls. So we have to pipe the content
+        # into a temporary file before we call into kobo.rpmlib.
+        with tempfile.NamedTemporaryFile(suffix="pubtools-pulplib-fake") as f:
+            # While we're at it, we can calculate each of the checksum types expected to
+            # exist on the unit.
+            hashers = {
+                "md5sum": hashlib.md5(),
+                "sha1sum": hashlib.sha1(),
+                "sha256sum": hashlib.sha256(),
+            }
+
+            while True:
+                chunk = content.read(1024 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
+                for hasher in hashers.values():
+                    hasher.update(chunk)
+
+            sumattrs = {}
+            for (sumtype, hasher) in hashers.items():
+                sumattrs[sumtype] = hasher.hexdigest()
+
+            # Read all the other attrs out of the RPM header.
+            f.flush()
+            f.seek(0)
+            header = get_rpm_header(f)
+
+        rpmattrs = get_header_fields(
+            header, ["name", "version", "release", "arch", "epochnum", "sourcerpm"]
+        )
+
+        # Fill in some special cases:
+        # This one uses a different name in the unit vs header.
+        rpmattrs["epoch"] = str(rpmattrs.pop("epochnum"))
+
+        # This one is derived from multiple headers.
+        rpmattrs["signing_key"] = get_keys_from_header(header)
+        if rpmattrs["signing_key"]:
+            rpmattrs["signing_key"] = rpmattrs["signing_key"].lower()
+
+        # This isn't actually a property of the RPM at all, but something synthesized.
+        rpmattrs["filename"] = "{name}-{version}-{release}.{arch}.rpm".format(
+            **rpmattrs
+        )
+
+        rpmattrs["requires"] = [
+            RpmDependency._from_data(item) for item in get_rpm_requires(header)
+        ]
+        rpmattrs["provides"] = [
+            RpmDependency._from_data(item) for item in get_rpm_provides(header)
+        ]
+
+        rpmattrs.update(sumattrs)
+
+        return RpmUnit(unit_id=self.next_unit_id(), **rpmattrs)
+
+    def make_module_units(self, content, repo_id):
+        # Note: consider using libmodulemd here once there is no need for this
+        # code to support legacy (pre-RHEL8) environments.
+        docs = list(yaml.load_all(content, Loader=yaml.BaseLoader))
+
+        out = []
+        for doc in docs:
+            attrs = {}
+
+            doc_type = doc.get("document")
+            data = doc.get("data") or {}
+
+            if doc_type == "modulemd":
+                klass = ModulemdUnit
+
+                # Pulp does not store entire 'artifacts' but only the 'rpms'
+                # subkey
+                artifacts = data.pop("artifacts", None)
+                if artifacts and "rpms" in artifacts:
+                    attrs["artifacts"] = artifacts["rpms"]
+
+            elif doc_type == "modulemd-defaults":
+                klass = ModulemdDefaultsUnit
+
+                # This is always initialized using the repo for which we're uploading.
+                attrs["repo_id"] = repo_id
+
+                # For whatever reason, pulp renames this field, so it won't
+                # be picked up by the generic attrs<=>unit mapping below.
+                if "module" in data:
+                    attrs["name"] = data["module"]
+
+            else:
+                # Pulp silently ignores any unknown document types, so we do the same.
+                LOG.debug(
+                    "FakeClient ignoring modulemd document of unknown type '%s'",
+                    doc_type,
+                )
+                continue
+
+            # attr names match the names used in modulemd data, so they can
+            # simply be copied across.
+            fields = [f.name for f in attr.fields(klass)]
+            for field in fields:
+                if field in data:
+                    attrs[field] = data[field]
+
+            # Note: if any mandatory fields are missing, or conversions can't
+            # happen, this is where we crash.
+            out.append(klass(unit_id=self.next_unit_id(), **attrs))
+
+        return out
 
 
 def is_erratum_version_newer(old_erratum, new_erratum):
@@ -134,140 +289,7 @@ def merge_units(old_unit, new_unit):
         # field, we do not currently attempt to reproduce this in the fake.
         new_unit = old_unit
 
-    return attr.evolve(new_unit, repository_memberships=repos)
-
-
-def make_iso_unit(unit_key):
-    # All needed info is always provided up-front in the unit key.
-    return FileUnit(
-        path=unit_key["name"], size=unit_key["size"], sha256sum=unit_key["checksum"]
-    )
-
-
-def make_yum_repo_metadata_unit(unit_key, unit_metadata):
-    # For expected fields in unit_key vs metadata, refer to:
-    # https://github.com/pulp/pulp_rpm/blob/5c5a7dcc058b29d89b3a913d29cfcab41db96686/plugins/pulp_rpm/plugins/importers/yum/upload.py#L246
-    return YumRepoMetadataFileUnit(
-        data_type=unit_key["data_type"], sha256sum=unit_metadata["checksum"]
-    )
-
-
-def make_erratum_unit(metadata):
-    md = metadata.copy()
-    md["_content_type_id"] = "erratum"
-    return ErratumUnit.from_data(md)
-
-
-def make_rpm_unit(content):
-    # Since the native RPM library is used under the hood here,
-    # any old file-like object isn't good enough; it *must* be a real file with
-    # a 'fileno' which can be passed into syscalls. So we have to pipe the content
-    # into a temporary file before we call into kobo.rpmlib.
-    with tempfile.NamedTemporaryFile(suffix="pubtools-pulplib-fake") as f:
-        # While we're at it, we can calculate each of the checksum types expected to
-        # exist on the unit.
-        hashers = {
-            "md5sum": hashlib.md5(),
-            "sha1sum": hashlib.sha1(),
-            "sha256sum": hashlib.sha256(),
-        }
-
-        while True:
-            chunk = content.read(1024 * 1024)
-            if not chunk:
-                break
-            f.write(chunk)
-            for hasher in hashers.values():
-                hasher.update(chunk)
-
-        sumattrs = {}
-        for (sumtype, hasher) in hashers.items():
-            sumattrs[sumtype] = hasher.hexdigest()
-
-        # Read all the other attrs out of the RPM header.
-        f.flush()
-        f.seek(0)
-        header = get_rpm_header(f)
-
-    rpmattrs = get_header_fields(
-        header, ["name", "version", "release", "arch", "epochnum", "sourcerpm"]
-    )
-
-    # Fill in some special cases:
-    # This one uses a different name in the unit vs header.
-    rpmattrs["epoch"] = str(rpmattrs.pop("epochnum"))
-
-    # This one is derived from multiple headers.
-    rpmattrs["signing_key"] = get_keys_from_header(header)
-    if rpmattrs["signing_key"]:
-        rpmattrs["signing_key"] = rpmattrs["signing_key"].lower()
-
-    # This isn't actually a property of the RPM at all, but something synthesized.
-    rpmattrs["filename"] = "{name}-{version}-{release}.{arch}.rpm".format(**rpmattrs)
-
-    rpmattrs["requires"] = [
-        RpmDependency._from_data(item) for item in get_rpm_requires(header)
-    ]
-    rpmattrs["provides"] = [
-        RpmDependency._from_data(item) for item in get_rpm_provides(header)
-    ]
-
-    rpmattrs.update(sumattrs)
-
-    return RpmUnit(**rpmattrs)
-
-
-def make_module_units(content, repo_id):
-    # Note: consider using libmodulemd here once there is no need for this
-    # code to support legacy (pre-RHEL8) environments.
-    docs = list(yaml.load_all(content, Loader=yaml.BaseLoader))
-
-    out = []
-    for doc in docs:
-        attrs = {}
-
-        doc_type = doc.get("document")
-        data = doc.get("data") or {}
-
-        if doc_type == "modulemd":
-            klass = ModulemdUnit
-
-            # Pulp does not store entire 'artifacts' but only the 'rpms'
-            # subkey
-            artifacts = data.pop("artifacts", None)
-            if artifacts and "rpms" in artifacts:
-                attrs["artifacts"] = artifacts["rpms"]
-
-        elif doc_type == "modulemd-defaults":
-            klass = ModulemdDefaultsUnit
-
-            # This is always initialized using the repo for which we're uploading.
-            attrs["repo_id"] = repo_id
-
-            # For whatever reason, pulp renames this field, so it won't
-            # be picked up by the generic attrs<=>unit mapping below.
-            if "module" in data:
-                attrs["name"] = data["module"]
-
-        else:
-            # Pulp silently ignores any unknown document types, so we do the same.
-            LOG.debug(
-                "FakeClient ignoring modulemd document of unknown type '%s'", doc_type
-            )
-            continue
-
-        # attr names match the names used in modulemd data, so they can
-        # simply be copied across.
-        fields = [f.name for f in attr.fields(klass)]
-        for field in fields:
-            if field in data:
-                attrs[field] = data[field]
-
-        # Note: if any mandatory fields are missing, or conversions can't
-        # happen, this is where we crash.
-        out.append(klass(**attrs))
-
-    return out
+    return attr.evolve(new_unit, unit_id=old_unit.unit_id, repository_memberships=repos)
 
 
 def make_unit_key(unit):

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -512,6 +512,10 @@ class YumRepository(Repository):
         # in unit dicts on read, is passed as a separate parameter on write.
         type_id = erratum_dict.pop("_content_type_id")
 
+        # Drop this because the caller cannot influence the _id (unit id)
+        # for uploaded units.
+        del erratum_dict["_id"]
+
         # And drop this one because repository_memberships is synthesized when
         # Pulp renders units, and can't be set during import.
         del erratum_dict["repository_memberships"]

--- a/pubtools/pulplib/_impl/model/unit/erratum.py
+++ b/pubtools/pulplib/_impl/model/unit/erratum.py
@@ -388,3 +388,9 @@ class ErratumUnit(Unit):
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.
     """
+
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -89,6 +89,12 @@ class FileUnit(Unit):
     .. versionadded:: 2.6.0
     """
 
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """
+
     @size.validator
     def _check_size(self, _, value):
         if value < 0:

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -64,6 +64,13 @@ class ModulemdUnit(Unit):
 
     .. versionadded:: 2.6.0
     """
+
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """
+
     artifacts = pulp_attrib(
         default=None,
         type=list,

--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -39,3 +39,9 @@ class ModulemdDefaultsUnit(Unit):
 
     .. versionadded:: 2.6.0
     """
+
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """

--- a/pubtools/pulplib/_impl/model/unit/repo_metadata.py
+++ b/pubtools/pulplib/_impl/model/unit/repo_metadata.py
@@ -36,3 +36,9 @@ class YumRepoMetadataFileUnit(Unit):
     )
     """IDs of repositories containing the unit, or ``None`` if this information is unavailable.
     """
+
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -189,6 +189,12 @@ class RpmUnit(Unit):
     .. versionadded:: 2.6.0
     """
 
+    unit_id = pulp_attrib(type=str, pulp_field="_id", default=None)
+    """The unique ID of this unit, if known.
+
+    .. versionadded:: 2.20.0
+    """
+
     requires = pulp_attrib(
         default=None,
         type=list,

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -466,6 +466,7 @@ def test_can_search_content(client, requests_mocker):
     assert sorted(units) == [
         RpmUnit(
             content_type_id="srpm",
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="src",
             epoch="0",
@@ -476,6 +477,7 @@ def test_can_search_content(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="ia64",
             epoch="0",
@@ -486,6 +488,7 @@ def test_can_search_content(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="d4633746-1ccc-4d85-9733-0007c87e0724",
             sha1sum="ca995eb1a635c97393466f67aaec8e9e753b8ed5",
             sha256sum="1c4baac658fd56e6ec9cca37f440a4bd8c9c0b02a21f41b30b8ea17b402a1907",
             arch="i386",
@@ -580,6 +583,7 @@ def test_can_search_content_pagination(client, requests_mocker):
     # It should have returned the repos as objects
     assert sorted(units) == [
         RpmUnit(
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             content_type_id="srpm",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="src",
@@ -591,6 +595,7 @@ def test_can_search_content_pagination(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="ia64",
             epoch="0",
@@ -601,6 +606,7 @@ def test_can_search_content_pagination(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="d4633746-1ccc-4d85-9733-0007c87e0724",
             sha1sum="ca995eb1a635c97393466f67aaec8e9e753b8ed5",
             sha256sum="1c4baac658fd56e6ec9cca37f440a4bd8c9c0b02a21f41b30b8ea17b402a1907",
             arch="i386",
@@ -645,6 +651,7 @@ def test_can_search_content_by_type(client, requests_mocker):
     # It should have returned the expected units
     assert sorted(units) == [
         RpmUnit(
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             content_type_id="srpm",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="src",
@@ -656,6 +663,7 @@ def test_can_search_content_by_type(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="bd2e0321-48f6-4997-a5dc-e73c771bc17d",
             sha256sum="4f5a3a0da6f404f6d9988987cd75f13982bd655a0a4f692406611afbbc597679",
             arch="ia64",
             epoch="0",
@@ -666,6 +674,7 @@ def test_can_search_content_by_type(client, requests_mocker):
             version="2.3.4",
         ),
         RpmUnit(
+            unit_id="d4633746-1ccc-4d85-9733-0007c87e0724",
             sha1sum="ca995eb1a635c97393466f67aaec8e9e753b8ed5",
             sha256sum="1c4baac658fd56e6ec9cca37f440a4bd8c9c0b02a21f41b30b8ea17b402a1907",
             arch="i386",

--- a/tests/fake/test_fake_copy_content.py
+++ b/tests/fake/test_fake_copy_content.py
@@ -121,12 +121,14 @@ def test_copy_content_all(controller):
     # because repository_memberships has been updated.
     assert sorted(dest_units, key=repr) == [
         ErratumUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             id="RHSA-1111:22",
             summary="Fixes bad things",
             content_type_id="erratum",
             repository_memberships=["dest-repo"],
         ),
         ModulemdUnit(
+            unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
             name="module1",
             stream="s1",
             version=1234,
@@ -136,6 +138,7 @@ def test_copy_content_all(controller):
             repository_memberships=["dest-repo", "repoA", "repoB"],
         ),
         RpmUnit(
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
             name="bash",
             version="4.0",
             release="1",
@@ -191,6 +194,7 @@ def test_copy_content_with_criteria(controller):
     dest_units = list(dest.search_content())
     assert sorted(dest_units, key=repr) == [
         RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             name="bash",
             version="4.0",
             release="1",
@@ -199,6 +203,7 @@ def test_copy_content_with_criteria(controller):
             repository_memberships=["dest-repo"],
         ),
         RpmUnit(
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
             name="bash",
             version="4.1",
             release="3",

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -98,8 +98,15 @@ def test_search_content_by_type(populated_repo):
     crit = Criteria.with_field("content_type_id", "rpm")
     units = list(populated_repo.search_content(crit))
     assert sorted(units) == [
-        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
         RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+        ),
+        RpmUnit(
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
             name="glibc",
             version="5.0",
             release="1",
@@ -114,7 +121,13 @@ def test_search_erratum_by_type(populated_repo):
 
     crit = Criteria.with_field("content_type_id", "erratum")
     units = list(populated_repo.search_content(crit))
-    assert units == [ErratumUnit(id="RHBA-1234:56", summary="The best advisory")]
+    assert units == [
+        ErratumUnit(
+            unit_id="85776e9a-dd84-f39e-7154-5a137a1d5006",
+            id="RHBA-1234:56",
+            summary="The best advisory",
+        )
+    ]
 
 
 def test_search_content_by_unit_field(populated_repo):
@@ -124,9 +137,20 @@ def test_search_content_by_unit_field(populated_repo):
     units = list(populated_repo.search_content(crit))
     assert sorted(units) == [
         RpmUnit(
-            content_type_id="srpm", name="bash", version="4.0", release="1", arch="src"
+            unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
+            content_type_id="srpm",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="src",
         ),
-        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+        ),
     ]
 
 
@@ -137,10 +161,20 @@ def test_search_content_by_unit_type(populated_repo):
     units = list(populated_repo.search_content(crit))
     assert sorted(units) == [
         ModulemdUnit(
-            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+            unit_id="23a7711a-8133-2876-37eb-dcd9e87a1613",
+            name="module1",
+            stream="s1",
+            version=1234,
+            context="a1b2",
+            arch="x86_64",
         ),
         ModulemdUnit(
-            name="module2", stream="s2", version=1234, context="a1b2", arch="x86_64"
+            unit_id="e6f4590b-9a16-4106-cf6a-659eb4862b21",
+            name="module2",
+            stream="s2",
+            version=1234,
+            context="a1b2",
+            arch="x86_64",
         ),
     ]
 
@@ -157,7 +191,18 @@ def test_search_content_mixed_fields(populated_repo):
     # Note: sorting different types not natively supported, hence sorting by repr
     assert sorted(units, key=repr) == [
         ModulemdUnit(
-            name="module1", stream="s1", version=1234, context="a1b2", arch="x86_64"
+            unit_id="23a7711a-8133-2876-37eb-dcd9e87a1613",
+            name="module1",
+            stream="s1",
+            version=1234,
+            context="a1b2",
+            arch="x86_64",
         ),
-        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+        ),
     ]

--- a/tests/fake/test_fake_upload_erratum.py
+++ b/tests/fake/test_fake_upload_erratum.py
@@ -46,7 +46,10 @@ def test_can_upload_units():
     # And they should be this
     assert units_in_repo == [
         ErratumUnit(
-            id="RHBA-1234:56", summary="test advisory", repository_memberships=["repo1"]
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+            id="RHBA-1234:56",
+            summary="test advisory",
+            repository_memberships=["repo1"],
         )
     ]
 
@@ -92,6 +95,7 @@ def test_upload_overwrite():
 
     assert units_repo1 == [
         ErratumUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             id="RHBA-1234:56",
             summary="updated test advisory",
             description="I've altered the deal",
@@ -101,6 +105,7 @@ def test_upload_overwrite():
     ]
     assert units_repo2 == [
         ErratumUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             id="RHBA-1234:56",
             summary="updated test advisory",
             description="I've altered the deal",
@@ -108,6 +113,7 @@ def test_upload_overwrite():
             repository_memberships=["repo1", "repo2"],
         ),
         ErratumUnit(
+            unit_id="e6f4590b-9a16-4106-cf6a-659eb4862b21",
             id="RHBA-1234:57",
             summary="a different advisory",
             repository_memberships=["repo2"],
@@ -153,6 +159,7 @@ def test_upload_overwrite_noop():
 
     assert units_repo1 == [
         ErratumUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             id="RHBA-1234:56",
             summary="test advisory",
             version="3",

--- a/tests/fake/test_fake_upload_file.py
+++ b/tests/fake/test_fake_upload_file.py
@@ -44,12 +44,14 @@ def test_can_upload_units(tmpdir):
             size=10,
             sha256sum="94c0c9d847ecaa45df01999676db772e5cb69cc54e1ff9db31d02385c56a86e1",
             repository_memberships=["repo1"],
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
         ),
         FileUnit(
             path="some-file.txt",
             size=29,
             sha256sum="fad3fc1e6d583b2003ec0a5273702ed8fcc2504271c87c40d9176467ebe218cb",
             repository_memberships=["repo1"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         ),
     ]
 
@@ -84,6 +86,7 @@ def test_replace_file(tmpdir):
             size=10,
             sha256sum="94c0c9d847ecaa45df01999676db772e5cb69cc54e1ff9db31d02385c56a86e1",
             repository_memberships=["repo1"],
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
         )
     ]
 
@@ -96,6 +99,7 @@ def test_replace_file(tmpdir):
             sha256sum="fad3fc1e6d583b2003ec0a5273702ed8fcc2504271c87c40d9176467ebe218cb",
             content_type_id="iso",
             repository_memberships=[],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         )
     ]
 

--- a/tests/fake/test_fake_upload_metadata.py
+++ b/tests/fake/test_fake_upload_metadata.py
@@ -50,6 +50,7 @@ def test_can_upload_units(use_file_object, tmpdir):
             sha256sum="0d22cdcc10e6d049dbe1af5123d50873fdfc1a4f58306e58cb6241be9472014d",
             content_type_id="yum_repo_metadata_file",
             repository_memberships=["repo1"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         )
     ]
 
@@ -81,6 +82,7 @@ def test_overwrite(tmpdir):
             sha256sum="0d22cdcc10e6d049dbe1af5123d50873fdfc1a4f58306e58cb6241be9472014d",
             content_type_id="yum_repo_metadata_file",
             repository_memberships=["repo1"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         )
     ]
 
@@ -97,6 +99,7 @@ def test_overwrite(tmpdir):
             sha256sum="a3ead5eedad5df82318c51685dbc1c147a36d1ff8584fc82de6b08d0bf63a795",
             content_type_id="yum_repo_metadata_file",
             repository_memberships=["repo1"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         )
     ]
 
@@ -113,11 +116,13 @@ def test_overwrite(tmpdir):
             sha256sum="a3ead5eedad5df82318c51685dbc1c147a36d1ff8584fc82de6b08d0bf63a795",
             content_type_id="yum_repo_metadata_file",
             repository_memberships=["repo1"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
         ),
         YumRepoMetadataFileUnit(
             data_type="mdtype2",
             sha256sum="a3ead5eedad5df82318c51685dbc1c147a36d1ff8584fc82de6b08d0bf63a795",
             content_type_id="yum_repo_metadata_file",
             repository_memberships=["repo1"],
+            unit_id="e6f4590b-9a16-4106-cf6a-659eb4862b21",
         ),
     ]

--- a/tests/fake/test_fake_upload_modules.py
+++ b/tests/fake/test_fake_upload_modules.py
@@ -49,6 +49,7 @@ def test_can_upload_units(use_file_object, data_path):
     # And they should be this
     assert units_in_repo == [
         ModulemdDefaultsUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             name="ant",
             repo_id="repo1",
             # Note, this tests that 1.10 does not get coerced to 1.1,
@@ -59,6 +60,7 @@ def test_can_upload_units(use_file_object, data_path):
             repository_memberships=["repo1"],
         ),
         ModulemdDefaultsUnit(
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
             name="dwm",
             repo_id="repo1",
             stream=None,
@@ -72,6 +74,7 @@ def test_can_upload_units(use_file_object, data_path):
             repository_memberships=["repo1"],
         ),
         ModulemdUnit(
+            unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
             name="avocado-vt",
             stream="82lts",
             version=3420210902113311,
@@ -91,6 +94,7 @@ def test_can_upload_units(use_file_object, data_path):
             },
         ),
         ModulemdUnit(
+            unit_id="23a7711a-8133-2876-37eb-dcd9e87a1613",
             name="dwm",
             stream="6.0",
             version=3420210201213909,

--- a/tests/fake/test_fake_upload_rpm.py
+++ b/tests/fake/test_fake_upload_rpm.py
@@ -44,6 +44,7 @@ def test_can_upload_units(data_path, use_file_object):
     # And they should be this
     assert units_in_repo == [
         RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
             name="walrus",
             version="5.21",
             release="1",

--- a/tests/unit/test_erratum_roundtrip.py
+++ b/tests/unit/test_erratum_roundtrip.py
@@ -28,7 +28,6 @@ def test_erratum_roundtrip(data_path):
 
     # A couple of fields synthesized in the Pulp response don't make it
     # into our model
-    del original_data["_id"]
     del original_data["_last_updated"]
     del original_data["_href"]
     del original_data["children"]

--- a/tests/unit/test_sample_erratum.py
+++ b/tests/unit/test_sample_erratum.py
@@ -668,6 +668,7 @@ def test_can_load_erratum(data_path):
     loaded = attr.evolve(loaded, pkglist=[], references=[])
 
     assert loaded == ErratumUnit(
+        unit_id="d003313d-2272-4ba3-8ea9-820269284dc2",
         id="RHSA-2019:0975",
         version="1",
         status="final",


### PR DESCRIPTION
Every unit in Pulp has a unique ID. This was not previously exposed as
it seems a good idea to hide that implementation detail if practical.

Add it now to serve the use-case of adjusting pulp_user_metadata fields
on units, for which the API is:

  /pulp/api/v2/content/units/<content_type>/<unit_id>/pulp_user_metadata/

There is no reasonable way to support this API without including unit_id
on the model, so it must be added.

Most of the complexity here is in the fake client, which must generate
unique IDs for units in a deterministic manner so that tests have stable
behavior.