### PR TITLE
tests: lock coverage at 100% via pytest-cov

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=pubtools {posargs}
+	pytest --cov-report=html --cov=pubtools --cov-fail-under=100 {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Because codecov/patch has not been entirely effective at enforcing this
during CI.