### PR TITLE
Fix possibility of duplicates in repository_memberships

### DIFF
--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -53,5 +53,5 @@ def frozenlist_or_none_converter(obj, map_fn=(lambda x: x)):
 
 
 frozenlist_or_none_sorted_converter = functools.partial(
-    frozenlist_or_none_converter, map_fn=sorted
+    frozenlist_or_none_converter, map_fn=lambda x: sorted(set(x))
 )

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -33,6 +33,24 @@ def test_stable_order(model_object, field_name):
     assert getattr(obj1, field_name) == getattr(obj2, field_name)
 
 
+@pytest.mark.parametrize("field_name", ["repository_memberships"])
+def test_unique(model_object, field_name):
+    """Test that certain list fields on the given object enforce uniqueness."""
+
+    if not hasattr(model_object, field_name):
+        pytest.skip("This object does not have %s" % field_name)
+
+    updates1 = {field_name: ["a", "a", "b", "b", "c"]}
+    updates2 = {field_name: ["a", "b", "c"]}
+
+    # Request two different updates on the object.
+    obj1 = attr.evolve(model_object, **updates1)
+    obj2 = attr.evolve(model_object, **updates2)
+
+    # The result should be exactly the same in both cases.
+    assert getattr(obj1, field_name) == getattr(obj2, field_name)
+
+
 def public_model_objects():
     """Returns a default-constructed instance of every public model class
     found in pubtools.pulplib.


### PR DESCRIPTION
It is not possible for a unit to belong to the same repo more than once,
so duplicates in repository_memberships shouldn't be allowed. Enforce
that in the converter, at the same time as we're sorting it.