### PR TITLE
fake: support orphans, fix missing repository_memberships on insert

### DIFF
--- a/pubtools/pulplib/_impl/fake/controller.py
+++ b/pubtools/pulplib/_impl/fake/controller.py
@@ -72,13 +72,17 @@ class FakeController(object):
 
         Args:
             repository (:class:`~pubtools.pulplib.Repository`)
-                A repository object.
+                A repository object, or ``None`` to insert units as orphans.
             units (list[:class:`~pubtools.pulplib.Unit`])
                 A list of units to be inserted.
 
         .. versionadded:: 1.5.0
+
+        .. versionadded:: 2.21.0
+            Added ability to insert orphan units.
         """
-        self.client._insert_repo_units(repository.id, units)
+        repo_id = repository.id if repository else None
+        self.client._insert_repo_units(repo_id, units)
 
     @property
     def content_type_ids(self):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.20.0",
+    version="2.21.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake_copy_content.py
+++ b/tests/fake/test_fake_copy_content.py
@@ -125,7 +125,7 @@ def test_copy_content_all(controller):
             id="RHSA-1111:22",
             summary="Fixes bad things",
             content_type_id="erratum",
-            repository_memberships=["dest-repo"],
+            repository_memberships=["src-repo", "dest-repo"],
         ),
         ModulemdUnit(
             unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
@@ -135,7 +135,7 @@ def test_copy_content_all(controller):
             context="a1b2",
             arch="x86_64",
             content_type_id="modulemd",
-            repository_memberships=["dest-repo", "repoA", "repoB"],
+            repository_memberships=["src-repo", "dest-repo", "repoA", "repoB"],
         ),
         RpmUnit(
             unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
@@ -147,7 +147,7 @@ def test_copy_content_all(controller):
             signing_key="a1b2c3",
             filename="bash-4.0-1.x86_64.rpm",
             content_type_id="rpm",
-            repository_memberships=["dest-repo"],
+            repository_memberships=["src-repo", "dest-repo"],
         ),
     ]
 
@@ -200,7 +200,7 @@ def test_copy_content_with_criteria(controller):
             release="1",
             arch="x86_64",
             epoch="0",
-            repository_memberships=["dest-repo"],
+            repository_memberships=["src-repo", "dest-repo"],
         ),
         RpmUnit(
             unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
@@ -209,6 +209,6 @@ def test_copy_content_with_criteria(controller):
             release="3",
             arch="x86_64",
             epoch="0",
-            repository_memberships=["dest-repo"],
+            repository_memberships=["src-repo", "dest-repo"],
         ),
     ]

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -104,6 +104,7 @@ def test_search_content_by_type(populated_repo):
             version="4.0",
             release="1",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
         RpmUnit(
             unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
@@ -112,6 +113,7 @@ def test_search_content_by_type(populated_repo):
             release="1",
             arch="x86_64",
             sourcerpm="glibc-5.0-1.el5_11.1.src.rpm",
+            repository_memberships=["repo1"],
         ),
     ]
 
@@ -126,6 +128,7 @@ def test_search_erratum_by_type(populated_repo):
             unit_id="85776e9a-dd84-f39e-7154-5a137a1d5006",
             id="RHBA-1234:56",
             summary="The best advisory",
+            repository_memberships=["repo1"],
         )
     ]
 
@@ -143,6 +146,7 @@ def test_search_content_by_unit_field(populated_repo):
             version="4.0",
             release="1",
             arch="src",
+            repository_memberships=["repo1"],
         ),
         RpmUnit(
             unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
@@ -150,6 +154,7 @@ def test_search_content_by_unit_field(populated_repo):
             version="4.0",
             release="1",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
     ]
 
@@ -167,6 +172,7 @@ def test_search_content_by_unit_type(populated_repo):
             version=1234,
             context="a1b2",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
         ModulemdUnit(
             unit_id="e6f4590b-9a16-4106-cf6a-659eb4862b21",
@@ -175,6 +181,7 @@ def test_search_content_by_unit_type(populated_repo):
             version=1234,
             context="a1b2",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
     ]
 
@@ -197,6 +204,7 @@ def test_search_content_mixed_fields(populated_repo):
             version=1234,
             context="a1b2",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
         RpmUnit(
             unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
@@ -204,5 +212,6 @@ def test_search_content_mixed_fields(populated_repo):
             version="4.0",
             release="1",
             arch="x86_64",
+            repository_memberships=["repo1"],
         ),
     ]


### PR DESCRIPTION
When we use FakeController.insert_units to add units onto the fake:

- we should ensure that repository_memberships includes the target repo,
  which was previously missing.

- we should accept a repo of None, meaning orphaned content, as it is
  otherwise not possible to test orphan scenarios using the fake.