### PR TITLE
Update tox cov job to generate xml coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=pubtools --cov-fail-under=100 {posargs}
+	pytest --cov-report=html --cov-report=xml --cov=pubtools --cov-fail-under=100 {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Codecov action to upload coverage report was upgraded to v2.
However, the reports were not uploaded correctly as v2 accepts
coverage reports in xml format only. Hence, updating the cov
job in tox to generate coverage reports in xml instead of html.