### PR TITLE
Add FileUnit version and display_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Added `version`, `display_order` fields to `FileUnit`.
 
 ## [2.22.0] - 2022-01-25
 

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -49,6 +49,57 @@ class FileUnit(Unit):
     .. versionadded:: 2.20.0
     """
 
+    version = pulp_attrib(
+        type=str,
+        pulp_field="pulp_user_metadata.version",
+        default=None,
+        validator=optional_str,
+    )
+    """A version string associated with this file.
+
+    This string can be used for display purposes to group
+    related files together. For example, files ``"oc-4.8.10-linux.tar.gz"``
+    and ``"openshift-install-linux-4.8.10.tar.gz"`` in a repo may both
+    have a version string of ``"4.8.10"`` to indicate that the files relate
+    to the same product version.
+
+    This field is **mutable** and may be set by
+    :meth:`~FileRepository.upload_file` or
+    :meth:`~Client.update_content`.
+
+    .. versionadded:: 2.23.0
+    """
+
+    display_order = pulp_attrib(
+        type=float,
+        pulp_field="pulp_user_metadata.display_order",
+        default=None,
+        converter=lambda x: float(x) if x is not None else None,
+    )
+    """An ordering hint associated with this file.
+
+    In cases where a UI displays a list of files from Pulp, it is suggested
+    that files by default should be ordered by this field ascending.
+
+    This field is **mutable** and may be set by
+    :meth:`~FileRepository.upload_file` or
+    :meth:`~Client.update_content`.
+
+    .. versionadded:: 2.23.0
+    """
+
+    @display_order.validator
+    def _validate_display_order(self, _, value):
+        # Validation here is identical to pushsource.FilePushItem.display_order.
+        # Check that validator for an explanation.
+        if value is None:
+            return
+
+        value = float(value)
+
+        if not (value >= -99999 and value <= 99999):
+            raise ValueError("display_order must be within range -99999 .. 99999")
+
     cdn_path = pulp_attrib(
         type=str,
         pulp_field="pulp_user_metadata.cdn_path",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.22.0",
+    version="2.23.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_update_content.py
+++ b/tests/client/test_update_content.py
@@ -35,6 +35,9 @@ def test_can_update_content(requests_mocker, client):
         description="A unit I'm about to update",
         cdn_published=datetime.datetime(2021, 12, 6, 11, 19, 0),
         path="x",
+        version="1.0.0",
+        # display_order will tolerate strings
+        display_order="2.3",
         size=0,
         sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     )
@@ -61,6 +64,8 @@ def test_can_update_content(requests_mocker, client):
         "cdn_path": None,
         "cdn_published": "2021-12-06T11:19:00Z",
         "description": "A unit I'm about to update",
+        "display_order": 2.3,
+        "version": "1.0.0",
     }
 
 

--- a/tests/fake/test_fake_update_content.py
+++ b/tests/fake/test_fake_update_content.py
@@ -54,7 +54,10 @@ def test_can_update_content(tmpdir):
     somefile.write(b"there is some binary data:\x00\x01\x02")
 
     upload_f = repo1.upload_file(
-        str(somefile), description="My great file", cdn_path="/foo/bar.txt"
+        str(somefile),
+        description="My great file",
+        version="1.0",
+        cdn_path="/foo/bar.txt",
     )
 
     # The future should resolve successfully
@@ -76,6 +79,7 @@ def test_can_update_content(tmpdir):
         unit,
         size=1000,
         description="My greater file",
+        display_order=10,
         cdn_published=datetime.datetime(2021, 12, 6, 11, 19, 0),
     )
 
@@ -92,7 +96,9 @@ def test_can_update_content(tmpdir):
     # The mutable fields on the unit after update should be as expected:
     assert unit_after_update.description == "My greater file"
     assert unit_after_update.cdn_published == datetime.datetime(2021, 12, 6, 11, 19, 0)
+    assert unit_after_update.display_order == 10
     # This one didn't change since it wasn't evolved
     assert unit_after_update.cdn_path == "/foo/bar.txt"
+    assert unit_after_update.version == "1.0"
     # This one didn't change (even though we tried) because it's not mutable
     assert unit_after_update.size == 29

--- a/tests/fake/test_fake_upload_usermeta.py
+++ b/tests/fake/test_fake_upload_usermeta.py
@@ -39,7 +39,10 @@ def test_can_upload_file_meta(tmpdir):
     somefile.write(b"there is some binary data:\x00\x01\x02")
 
     upload_f = repo1.upload_file(
-        str(somefile), description="My great file", cdn_path="/foo/bar.txt"
+        str(somefile),
+        description="My great file",
+        cdn_path="/foo/bar.txt",
+        version="2.0",
     )
 
     # The future should resolve successfully
@@ -59,6 +62,7 @@ def test_can_upload_file_meta(tmpdir):
     # Extra fields we passed during upload should be present here.
     assert unit.description == "My great file"
     assert unit.cdn_path == "/foo/bar.txt"
+    assert unit.version == "2.0"
 
 
 def test_can_reupload_file_meta(tmpdir):

--- a/tests/unit/test_file_unit.py
+++ b/tests/unit/test_file_unit.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from pubtools.pulplib import FileUnit
 
 
@@ -41,6 +43,21 @@ def test_zero_size():
         sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         content_type_id="iso",
     )
+
+
+def test_order_out_of_range():
+    """FileUnit rejects an order out of the allowed range."""
+
+    with pytest.raises(ValueError) as excinfo:
+        FileUnit(
+            path="my-empty-file",
+            size=0,
+            sha256sum="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            content_type_id="iso",
+            display_order=1e17,
+        )
+
+    assert "display_order must be within range -99999 .. 99999" in str(excinfo.value)
 
 
 def test_user_metadata_fields():


### PR DESCRIPTION
These fields traditionally have been embedded on the
ud_file_release_mappings_2 repository-level note. However, they really
should belong to each unit so they can be handled the same way as other
unit metadata and will be automatically copied across repos.

The idea here is to start allowing these to be set on units in the same
way as other fields, while elsewhere there will be code which compiles
ud_file_release_mappings_2 based on these values to maintain backwards
compatibility.