### PR TITLE
Set ud_file_release_mappings_2 during repo publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added `version`, `display_order` fields to `FileUnit`.
+- The `ud_file_release_mappings_2` repository note is now set on repos during publish.
 
 ## [2.22.0] - 2022-01-25
 

--- a/pubtools/pulplib/_impl/client/ud_mappings.py
+++ b/pubtools/pulplib/_impl/client/ud_mappings.py
@@ -1,0 +1,184 @@
+"""Helpers for generating UD-related repo notes."""
+import functools
+import os
+import logging
+import json
+
+from more_executors.futures import f_map, f_flat_map, f_return, f_zip
+
+from ..model import FileUnit
+from ..criteria import Criteria
+
+LOG = logging.getLogger("pubtools.pulplib")
+
+UD_MAPPINGS_NOTE = os.getenv("PULP_UD_MAPPINGS_NOTE") or "ud_file_release_mappings_2"
+
+
+class MappingsHelper(object):
+    """A wrapper for the raw release mappings dict.
+
+    This wrapper provides a utility function for adding items to the dict
+    while keeping track of whether any changes have been made.
+    """
+
+    def __init__(self, data):
+        self._data = data
+        self.changed = False
+
+    def set_file_mapping(self, version, filename, order):
+        """Ensure a mapping exists in the dict for a given
+        version, filename & order.
+
+        order can be None if no specific order is required.
+
+        Sets self.changed to True if any changes occur.
+        """
+
+        # Example of the structure we're updating:
+        #
+        # {
+        #   "4.8.10": [
+        #     {
+        #     "filename": "oc-4.8.10-linux.tar.gz",
+        #     "order": 1.0
+        #     },
+        #     {
+        #     "filename": "oc-4.8.10-macosx.zip",
+        #     "order": 3.0
+        #     },
+        #     ...,
+        #   ],
+        #   "4.8.11": [ ... ],
+        #   ...,
+        # }
+        if self._data.get(version) is None:
+            self._data[version] = []
+            self.changed = True
+
+        file_list = self._data[version]
+
+        file_dict = None
+        for elem in file_list:
+            if elem.get("filename") == filename:
+                file_dict = elem
+                break
+        else:
+            file_dict = {"filename": filename}
+            file_list.append(file_dict)
+            self.changed = True
+
+        if order is None:
+            # When asked to set an order of None we'll interpret it as
+            # a request to make no changes at all (rather than actually
+            # setting the order to none). This keeps the possibility open
+            # of ignoring pulplib logic and manually setting the order
+            # values to something else by standalone tools, without pulplib
+            # resetting the values every time a publish happens.
+            #
+            # It's intentional to make changes up to this point rather than
+            # returning early if order is None, because we need to ensure
+            # that filenames are put under the right 'version' even if there
+            # is no 'order'.
+            return
+
+        if order == file_dict.get("order"):
+            # Nothing to be changed
+            return
+
+        file_dict["order"] = order
+        self.changed = True
+
+    @property
+    def as_json(self):
+        """The mapping converted to JSON form, suitable for storing on Pulp."""
+        return json.dumps(self._data, sort_keys=True)
+
+
+def compile_ud_mappings(repo, do_request):
+    """Perform the UD mappings note compilation & update process for a given repo.
+
+    Arguments:
+        repo (~pulplib.FileRepository)
+            A repository.
+        do_request (callable)
+            A function which can be invoked to perform an HTTP request to Pulp.
+
+    Returns:
+        A Future, resolved when the update completes successfully.
+    """
+    LOG.debug("%s: compiling %s", repo.id, UD_MAPPINGS_NOTE)
+
+    # 1. Get current mappings.
+    #
+    # Requires a fresh retrieval of the repo since we don't store
+    # these mappings on our model.
+    #
+    repo_url = "pulp/api/v2/repositories/%s/" % repo.id
+
+    repo_raw_f = do_request(repo_url, method="GET")
+    mappings_f = f_map(
+        repo_raw_f, lambda data: (data.get("notes") or {}).get(UD_MAPPINGS_NOTE) or "{}"
+    )
+
+    # Mappings are stored as JSON, so decode them
+    mappings_f = f_map(mappings_f, json.loads)
+
+    # Wrap them in our helper for keeping track of changes
+    mappings_f = f_map(mappings_f, MappingsHelper)
+
+    # 2. Iterate over all files in the repo
+    files_f = repo.search_content(Criteria.with_unit_type(FileUnit))
+
+    # 3. Mutate the mappings as needed for each file
+    updated_mappings_f = f_flat_map(
+        f_zip(mappings_f, files_f),
+        lambda tup: update_mappings_for_files(tup[0], tup[1]),
+    )
+
+    # 4. Upload them back if any changes
+    handle_changes = functools.partial(
+        upload_changed_mappings, repo=repo, repo_url=repo_url, do_request=do_request
+    )
+    return f_flat_map(updated_mappings_f, handle_changes)
+
+
+def upload_changed_mappings(mappings, repo, repo_url, do_request):
+    """Upload mappings back to repo, if and only if they've been changed."""
+
+    if not mappings.changed:
+        LOG.debug("%s: no changes required to %s", repo.id, UD_MAPPINGS_NOTE)
+        return f_return()
+
+    body = {"delta": {"notes": {UD_MAPPINGS_NOTE: mappings.as_json}}}
+
+    # Note: Pulp docs are a bit ambiguous with respect to whether a repo PUT
+    # will generate a task or not. In fact it generates tasks only if a
+    # distributor or importer is being updated. Hence the request here doesn't
+    # return a specific value, only a Future which succeeds if request
+    # succeeds.
+    update_f = do_request(repo_url, method="PUT", json=body)
+
+    return f_map(
+        update_f, lambda _: LOG.info("Updated %s in %s", UD_MAPPINGS_NOTE, repo.id)
+    )
+
+
+def update_mappings_for_files(mappings, file_page):
+    # Updates mappings for every file in a single page, plus all
+    # following pages (async).
+    #
+    # Returns Future[mappings] once all pages are processed.
+
+    for unit in file_page.data:
+        version = unit.version
+        if version:
+            mappings.set_file_mapping(version, unit.path, unit.display_order)
+
+    if not file_page.next:
+        # No more files, just return the mappings
+        return f_return(mappings)
+
+    # There's more files, keep going to the next page.
+    return f_flat_map(
+        file_page.next, lambda page: update_mappings_for_files(mappings, page)
+    )

--- a/tests/repository/test_ud_mappings.py
+++ b/tests/repository/test_ud_mappings.py
@@ -1,0 +1,260 @@
+import json
+import logging
+
+from pubtools.pulplib import FileRepository, Task, Distributor
+
+
+def test_publish_update_mappings(fast_poller, requests_mocker, client, caplog):
+    """Publish on FileRepository will generate ud_file_release_mappings_2."""
+
+    caplog.set_level(logging.INFO, "pubtools.pulplib")
+
+    repo = FileRepository(
+        id="some-repo",
+        distributors=[Distributor(id="iso_distributor", type_id="iso_distributor")],
+    )
+    repo.__dict__["_client"] = client
+
+    # Force client to use a small page size so that we're able to verify
+    # all pages end up handled.
+    client._PAGE_SIZE = 3
+
+    # Arrange for the repo to currently exist with some mappings.
+    requests_mocker.get(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/",
+        json={
+            "id": "some-repo",
+            "notes": {
+                "ud_file_release_mappings_2": json.dumps(
+                    # Define some mappings so there's a mix of data needing
+                    # an update and data needing no update.
+                    {
+                        "1.0": [{"filename": "file1", "order": 3.0}],
+                        "3.0": [{"filename": "file3", "order": 1234}],
+                        "4.0": [{"filename": "file4", "order": 0}],
+                        "some-other-version": [
+                            {"filename": "whatever-file", "order": "abc", "foo": "bar"}
+                        ],
+                    }
+                )
+            },
+        },
+    )
+
+    # Make the repo have some units with the mapping-relevant fields. We use
+    # two pages here to ensure that the code implements pagination.
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/search/units/",
+        [
+            {
+                # page 1
+                "json": [
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file1",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                            "pulp_user_metadata": {
+                                "version": "1.0",
+                                "display_order": 3.0,
+                            },
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file2",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file3",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                            "pulp_user_metadata": {"version": "3.0"},
+                        }
+                    },
+                ]
+            },
+            {
+                # page 2
+                "json": [
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file4",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                            "pulp_user_metadata": {
+                                "version": "4.0",
+                                "display_order": -2,
+                            },
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file5",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                            "pulp_user_metadata": {
+                                "version": "1.0",
+                                "display_order": 4.5,
+                            },
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "_content_type_id": "iso",
+                            "name": "file6",
+                            "size": 1,
+                            "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                            "pulp_user_metadata": {"version": "6.0"},
+                        }
+                    },
+                ]
+            },
+            {
+                # page 3: nothing more
+                "json": []
+            },
+        ],
+    )
+
+    # Allow for an update to the repository.
+    requests_mocker.put(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/", json={}
+    )
+
+    # It should publish as usual.
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/actions/publish/",
+        json={"spawned_tasks": [{"task_id": "publish-task"}]},
+    )
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        json=[{"task_id": "publish-task", "state": "finished"}],
+    )
+
+    # It should have succeeded, with the publish task as retrieved from pulp
+    assert sorted(repo.publish()) == [
+        Task(id="publish-task", succeeded=True, completed=True)
+    ]
+
+    # Now let's have a look at what it updated.
+    # The last operations are (update repo, start publish, await tasks),
+    # so the update request should always be the 3rd last.
+    req = requests_mocker.request_history[-3]
+
+    # Should have been a PUT to the repo.
+    assert req.url == "https://pulp.example.com/pulp/api/v2/repositories/some-repo/"
+    assert req.method == "PUT"
+
+    # It should have included this field in the delta...
+    mapping_json = req.json()["delta"]["notes"]["ud_file_release_mappings_2"]
+
+    # It should have been valid JSON
+    mapping = json.loads(mapping_json)
+
+    # It should be equal to this:
+    assert mapping == {
+        "1.0": [
+            # This file wasn't changed
+            {"filename": "file1", "order": 3.0},
+            # This was added
+            {"filename": "file5", "order": 4.5},
+        ],
+        # This wasn't touched because, although the repo has the file, it has no
+        # defined order
+        "3.0": [{"filename": "file3", "order": 1234}],
+        # This was updated
+        "4.0": [{"filename": "file4", "order": -2.0}],
+        # This was added, with the entire version not previously defined.
+        # Also, order field is omitted because none was in the data, but
+        # the version and file still must be written.
+        "6.0": [{"filename": "file6"}],
+        # This is some unrelated junk which should be left alone during the
+        # update process.
+        "some-other-version": [
+            {"filename": "whatever-file", "foo": "bar", "order": "abc"}
+        ],
+    }
+
+    # It should have logged that this happened
+    assert "Updated ud_file_release_mappings_2 in some-repo" in caplog.messages
+
+
+def test_publish_update_mappings_noop(fast_poller, requests_mocker, client):
+    """Publish on FileRepository does not do unnecessary repo updates."""
+    repo = FileRepository(
+        id="some-repo",
+        distributors=[Distributor(id="iso_distributor", type_id="iso_distributor")],
+    )
+    repo.__dict__["_client"] = client
+
+    # Arrange for the repo to currently exist with up-to-date mappings.
+    requests_mocker.get(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/",
+        json={
+            "id": "some-repo",
+            "notes": {
+                "ud_file_release_mappings_2": json.dumps(
+                    {
+                        "1.0": [
+                            {"filename": "file1", "order": 3.0},
+                            {"filename": "file2", "order": 6.0},
+                        ],
+                        "other": ["whatever"],
+                    }
+                )
+            },
+        },
+    )
+
+    # Make the repo have some units with the mapping-relevant fields.
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/search/units/",
+        json=[
+            {
+                "metadata": {
+                    "_content_type_id": "iso",
+                    "name": "file1",
+                    "size": 1,
+                    "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                    "pulp_user_metadata": {"version": "1.0", "display_order": 3.0},
+                }
+            },
+            {
+                "metadata": {
+                    "_content_type_id": "iso",
+                    "name": "file2",
+                    "size": 1,
+                    "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
+                    "pulp_user_metadata": {"version": "1.0"},
+                }
+            },
+        ],
+    )
+
+    # It should NOT update the repository, so we don't register any PUT.
+
+    # It should publish as usual.
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/repositories/some-repo/actions/publish/",
+        json={"spawned_tasks": [{"task_id": "publish-task"}]},
+    )
+
+    requests_mocker.post(
+        "https://pulp.example.com/pulp/api/v2/tasks/search/",
+        json=[{"task_id": "publish-task", "state": "finished"}],
+    )
+
+    # It should have succeeded, with the tasks as retrieved from Pulp
+    assert sorted(repo.publish()) == [
+        Task(id="publish-task", succeeded=True, completed=True)
+    ]


### PR DESCRIPTION
This is a repo-level note which needs to be set in certain cases to
control how files are displayed in UD.

The design around this note is a bit of a mess:

- the data structure is arbitrary

- data is encoded as JSON even though it could have been stored as
  a real dict

- the fields in this note could just as well be stored on individual
  units, as with the rest of per-file metadata

- the data doesn't get copied between repos when units are copied

- in practice, the release pipeline has never fully supported setting
  this note correctly, so releng are using other low-level tools after
  push to manipulate the values

For all these reasons, I don't want to expose any public API for this
and "taint" both this library and pubtools-pulp. For instance I don't
want to add this note onto the Repository model.

Instead, this behavior has been added as a semi-hidden implementation
detail which occurs whenever a FileRepository is published. The way it
works now is that the push code must store the relevant fields
directly on each unit (as it should have been in the first place);
then the code added here will look at those fields and "compile" them
into the required format on the mapping note.

The code is written so that it won't remove anything from the note, or
touch anything it doesn't understand. Therefore, workflows which use
other tools to manipulate the note should continue working.

This can be considered as something which only exists for compatibility
reasons, as it's now possible to access these unit fields in the same
way as any others rather than as a repo note. Hopefully it can be
removed some day.