### PR TITLE
refactor: use a namedtuple to improve debuggability

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 from functools import partial
+from collections import namedtuple
 
 import requests
 import six
@@ -30,6 +31,8 @@ from .ud_mappings import compile_ud_mappings
 
 
 LOG = logging.getLogger("pubtools.pulplib")
+
+UploadResult = namedtuple("UploadResult", ["checksum", "size"])
 
 
 class Client(object):
@@ -549,7 +552,7 @@ class Client(object):
                     lambda _: do_next_upload(checksum, size + len(data)),
                 )
             # nothing more to upload, return checksum and size
-            return f_return((checksum.hexdigest(), size))
+            return f_return(UploadResult(checksum.hexdigest(), size))
 
         is_file_object = "close" in dir(file_obj)
         if not is_file_object:

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -23,6 +23,7 @@ from pubtools.pulplib import (
     FileUnit,
     MaintenanceReport,
 )
+from pubtools.pulplib._impl.client.client import UploadResult
 from pubtools.pulplib._impl.client.search import search_for_criteria
 from .. import compat_attr as attr
 
@@ -468,7 +469,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
                 checksum.update(data)
                 size += len(data)
                 return do_next_upload(checksum, size)
-            return f_return((checksum.hexdigest(), size))
+            return f_return(UploadResult(checksum.hexdigest(), size))
 
         out = f_flat_map(f_return(), lambda _: do_next_upload(hashlib.sha256(), 0))
 


### PR DESCRIPTION
This is a tiny change replacing one usage of a bare tuple with
namedtuple. It provides a modest improvement in debuggability of the
code, due to the fact that \_\_repr\_\_ on Future will log the type of its
result (but not the value).

In other words, with this change some instances of the following in
tracebacks:

    <Future at 0x7f095c170990 state=finished returned tuple>

Will be replaced with the slightly more detailed:

    <Future at 0x7f095c170990 state=finished returned UploadResult>

This can help figure out which part of the code is at fault when a crash
occurs.