### PR TITLE
Deprecate support for legacy sigstore [CLOUDDST-5513]

### DIFF
--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -197,7 +197,11 @@ class Repository(PulpObject, Deletable):
 
     is_sigstore = pulp_attrib(default=False, type=bool)
     """True if this is a sigstore repository, used for container image manifest
-    signatures."""
+    signatures.
+
+    .. deprecated:: 2.24.0
+       The signatures are not stored in a Pulp repository any more.
+    """
 
     is_temporary = pulp_attrib(
         default=False,

--- a/pubtools/pulplib/_impl/model/repository/file.py
+++ b/pubtools/pulplib/_impl/model/repository/file.py
@@ -40,6 +40,12 @@ class FileRepository(Repository):
         type=bool,
         validator=validators.instance_of(bool),
     )
+    """True if this is a sigstore repository, used for container image manifest
+    signatures.
+
+    .. deprecated:: 2.24.0
+       The signatures are not stored in a Pulp repository any more.
+    """
 
     mutable_urls = attr.ib(
         default=attr.Factory(lambda: frozenlist(["PULP_MANIFEST"])),

--- a/pubtools/pulplib/_impl/model/repository/file.py
+++ b/pubtools/pulplib/_impl/model/repository/file.py
@@ -40,12 +40,6 @@ class FileRepository(Repository):
         type=bool,
         validator=validators.instance_of(bool),
     )
-    """True if this is a sigstore repository, used for container image manifest
-    signatures.
-
-    .. deprecated:: 2.24.0
-       The signatures are not stored in a Pulp repository any more.
-    """
 
     mutable_urls = attr.ib(
         default=attr.Factory(lambda: frozenlist(["PULP_MANIFEST"])),


### PR DESCRIPTION
This change deprecates the repository attribute `is_sigstore` as the signatures are not stored in a Pulp repository any more.

The next minor version 2.24 appears suitable for deprecation.