### PR TITLE
Improve verbosity of upload logs

### DIFF
--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -451,7 +451,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         return f_proxy(f_return(self._type_ids))
 
-    def _do_upload_file(self, upload_id, file_obj):
+    def _do_upload_file(
+        self, upload_id, file_obj, name="<unknown file>"
+    ):  # pylint: disable=unused-argument
         # We keep track of uploaded content as we may need it at import time.
         buffer = six.BytesIO()
         self._uploads_pending[upload_id] = buffer
@@ -518,7 +520,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         return f_return([task])
 
-    def _request_upload(self):
+    def _request_upload(self, name):  # pylint: disable=unused-argument
         upload_request = {
             "_href": "/pulp/api/v2/content/uploads/%s/" % self._next_request_id(),
             "upload_id": "%s" % self._next_request_id(),

--- a/pubtools/pulplib/_impl/log.py
+++ b/pubtools/pulplib/_impl/log.py
@@ -1,0 +1,52 @@
+import logging
+
+from monotonic import monotonic
+
+
+class TimedLogger(object):
+    """A helper to log messages only if a certain amount of time has passed
+    since the previous log.
+
+    Intended for loops where you want to log progress sometimes but you don't
+    know how fast the loop will run, making it potentially too spammy to
+    log at every iteration or even at some fixed interval of iterations.
+    """
+
+    def __init__(self, logger=None, interval=10):
+        """Construct a new timed logger.
+
+        Arguments:
+            logger
+                Underlying logger object to which messages will be routed.
+
+            interval
+                Minimum amount of time, in seconds, which must pass between
+                messages. Each time a message is logged, if the amount of
+                time passed since the previous log is less than this, the
+                message will be discarded.
+        """
+        logger = logger or logging.getLogger("pubtools.pulplib")
+
+        self._interval = interval
+
+        # We start counting from the time we're constructed. That means we
+        # won't produce any log message at all until we've been alive for at
+        # least 'interval' seconds.
+        self._last_log = monotonic()
+
+        # The log methods we support. Feel free to add others like warn/error
+        # if needed, but it's not clear there's a use-case.
+        self.debug = self._wrap(logger.debug)
+        self.info = self._wrap(logger.info)
+
+    def _wrap(self, logmethod):
+        def new_logmethod(*args, **kwargs):
+            now = monotonic()
+            if now - self._last_log < self._interval:
+                # Too soon, don't log yet
+                return
+            # OK, we should log
+            self._last_log = now
+            return logmethod(*args, **kwargs)
+
+        return new_logmethod

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -620,7 +620,7 @@ class Repository(PulpObject, Deletable):
         unit_metadata_fn = unit_metadata_fn or (lambda _: None)
 
         upload_id_f = f_map(
-            self._client._request_upload(), lambda upload: upload["upload_id"]
+            self._client._request_upload(name), lambda upload: upload["upload_id"]
         )
 
         f_map(
@@ -640,7 +640,9 @@ class Repository(PulpObject, Deletable):
         else:
             upload_complete_f = f_flat_map(
                 upload_id_f,
-                lambda upload_id: self._client._do_upload_file(upload_id, file_obj),
+                lambda upload_id: self._client._do_upload_file(
+                    upload_id, file_obj, name
+                ),
             )
 
         import_complete_f = f_flat_map(
@@ -656,7 +658,7 @@ class Repository(PulpObject, Deletable):
 
         f_map(
             import_complete_f,
-            lambda _: self._client._delete_upload_request(upload_id_f.result()),
+            lambda _: self._client._delete_upload_request(upload_id_f.result(), name),
         )
 
         return f_proxy(import_complete_f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonschema
 attrs
 frozenlist2
 pubtools>=0.3.0
+humanize


### PR DESCRIPTION
While creating/deleting upload IDs, let's log the name of the related
file. While uploading chunks, let's log progress info every now and
then.

The motivation for improving the logs is that there still seem to be
some performance issues with uploading large files, and it's hard to
tell what's going on without this info.