### PR TITLE
Make humanize a soft dependency

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 
 import requests
 import six
-import humanize
 from more_executors import Executors
 from more_executors.futures import f_map, f_flat_map, f_return, f_proxy, f_sequence
 from six.moves import StringIO
@@ -28,6 +27,7 @@ from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
 from . import retry
+from .humanize_compat import naturalsize
 
 from .ud_mappings import compile_ud_mappings
 
@@ -616,7 +616,7 @@ class Client(object):
                 upload_logger.info(
                     "Still uploading %s: %s%s [%s]",
                     name,
-                    humanize.naturalsize(size),
+                    naturalsize(size),
                     pct,
                     upload_id,
                 )

--- a/pubtools/pulplib/_impl/client/humanize_compat.py
+++ b/pubtools/pulplib/_impl/client/humanize_compat.py
@@ -1,0 +1,18 @@
+# Provide a simple fallback for humanize.naturalsize in
+# certain legacy environments.
+#
+# TODO: remove me once py2 support goes away.
+
+# pylint: disable=broad-except
+
+
+def fallback_naturalsize(value):
+    return "%.1f MB" % (float(value) / 1024 / 1024)
+
+
+try:
+    from humanize import naturalsize
+except Exception:  # pragma: no cover
+    naturalsize = fallback_naturalsize
+
+__all__ = ["naturalsize"]

--- a/tests/client/test_naturalsize.py
+++ b/tests/client/test_naturalsize.py
@@ -1,0 +1,22 @@
+# Simple tests for the humanize.naturalsize fallback used in legacy envs.
+#
+# TODO: remove me when py2 support is dropped.
+
+import pytest
+
+from pubtools.pulplib._impl.client.humanize_compat import (
+    fallback_naturalsize as naturalsize,
+)
+
+
+@pytest.mark.parametrize(
+    "input,expected_output",
+    [
+        (0, "0.0 MB"),
+        (23 * 1024 * 1024, "23.0 MB"),
+        (23 * 1000 * 1000, "21.9 MB"),
+        (13.5 * 1000 * 1024 * 1024, "13500.0 MB"),
+    ],
+)
+def test_naturalsize(input, expected_output):
+    assert naturalsize(input) == expected_output


### PR DESCRIPTION
2.25.0 introduced a dependency on 'humanize' library for some logging.
Though I verified this is available on RHEL6 before adding the dep, in
practice it is available via EPEL.

I'm not sure whether EPEL is available in all the necessary
environments.  Let's add a trivial fallback for cases where the package
is uninstallable.