### PR TITLE
Make most classes slots-based

### DIFF
--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -19,6 +19,12 @@ def s(*args, **kwargs):
     # using this library will surely not be tested solely on Py2.
     kwargs = kwargs.copy()
 
+    if "slots" not in kwargs:
+        # Slotted classes should be used where possible, but there
+        # are a few cases where it won't work, so the possibility
+        # is left open to disable it via slots=False.
+        kwargs["slots"] = True
+
     if "kw_only" in kwargs and sys.version_info < (3,):  # pragma: no cover
         # This is only implemented for Python 3.
         # attrs will raise if kw_only is provided on Py2.

--- a/pubtools/pulplib/_impl/model/common.py
+++ b/pubtools/pulplib/_impl/model/common.py
@@ -49,6 +49,8 @@ class PulpObject(object):
     # validate anything.
     _SCHEMA = False
 
+    __slots__ = ()
+
     @classmethod
     def from_data(cls, data):
         """Obtain a detached instance using data obtained from Pulp.
@@ -186,7 +188,7 @@ class PulpObject(object):
         return out
 
 
-@attr.s(kw_only=True, frozen=True)
+@attr.s(kw_only=True, frozen=True, slots=False)
 class WithClient(object):
     # A mixin for objects holding a private reference to client.
 

--- a/pubtools/pulplib/_impl/page.py
+++ b/pubtools/pulplib/_impl/page.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger("pubtools.pulplib")
 # pylint: disable=no-member
 
 
-@attr.s(kw_only=True, frozen=True)
+@attr.s(kw_only=True, frozen=True, slots=False)
 class Page(object):
     """A page of Pulp search results.
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.25.1",
+    version="2.26.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 import pubtools.pulplib
+from pubtools.pulplib import Distributor, Repository, Page
 
 from .assertions import assert_model_invariants
 
@@ -72,6 +73,21 @@ def test_datetime_str(model_object, field_name):
     # get the usual TypeError from trying to store a str in a datetime field.
     with pytest.raises(TypeError):
         attr.evolve(model_object, **{field_name: "oops not a timestamp"})
+
+
+def test_slots(model_object):
+    """Test that model uses slotted classes (other than a few exceptions)."""
+
+    # These classes are currently permitted to not use slots,
+    # because they were written to access __dict__ internally so as to
+    # hide some private fields from attrs.
+    #
+    # They could potentially be rewritten to avoid this and also start
+    # using slots, so this could be considered a TODO.
+    if isinstance(model_object, (Repository, Distributor, Page)):
+        pytest.xfail("not compatible with __slots__")
+
+    assert not hasattr(model_object, "__dict__")
 
 
 def public_model_objects():


### PR DESCRIPTION
Some tasks using this library are having memory usage issues. Slotted
classes should reduce memory usage, so let's use them where we can.

Note that this doesn't target *all* attr.s classes in the library
because some of them are currently written to make use of `self.__dict__`,
which doesn't exist for slotted classes. However, all the unit classes,
plus tasks, are covered. These are the important ones since it's typical
for code to be dealing with tens of thousands of these objects, while
only a handful of the other kinds of objects.