### PR TITLE
Customize __repr__ to reduce verbosity

### DIFF
--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -25,6 +25,11 @@ def s(*args, **kwargs):
         # is left open to disable it via slots=False.
         kwargs["slots"] = True
 
+    if "repr" not in kwargs:
+        # We provide our own __repr__ implementation in PulpObject, so
+        # don't use the attrs-generated repr by default
+        kwargs["repr"] = False
+
     if "kw_only" in kwargs and sys.version_info < (3,):  # pragma: no cover
         # This is only implemented for Python 3.
         # attrs will raise if kw_only is provided on Py2.
@@ -54,3 +59,4 @@ fields = attr.fields
 evolve = attr.evolve
 has = attr.has
 validators = attr.validators
+NOTHING = attr.NOTHING

--- a/pubtools/pulplib/_impl/model/common.py
+++ b/pubtools/pulplib/_impl/model/common.py
@@ -187,6 +187,30 @@ class PulpObject(object):
 
         return out
 
+    def __repr__(self):
+        # We provide a custom repr with one difference from the one generated
+        # by attrs:
+        # - The attrs repr includes all attributes
+        # - Ours includes only the attributes with non-default values
+        # Since we have a lot of optional attributes which are typically left
+        # at their default values, this helps make repr much less verbose and
+        # noisy for us.
+        class_name = self.__class__.__name__
+
+        fields = attr.fields(self.__class__)
+        kv = []
+        for field in fields:
+            if field.repr:
+                name = field.name
+                default = field.default
+                value = getattr(self, name, attr.NOTHING)
+                if value != default:
+                    kv.append((name, value))
+
+        return "{0}({1})".format(
+            class_name, ", ".join([name + "=" + repr(value) for (name, value) in kv])
+        )
+
 
 @attr.s(kw_only=True, frozen=True, slots=False)
 class WithClient(object):

--- a/tests/model/test_model_invariants.py
+++ b/tests/model/test_model_invariants.py
@@ -90,6 +90,12 @@ def test_slots(model_object):
     assert not hasattr(model_object, "__dict__")
 
 
+def test_repr(model_object):
+    """Test that repr successfully returns a string."""
+
+    assert isinstance(repr(model_object), str)
+
+
 def public_model_objects():
     """Returns a default-constructed instance of every public model class
     found in pubtools.pulplib.

--- a/tests/unit/test_rpm_unit.py
+++ b/tests/unit/test_rpm_unit.py
@@ -33,3 +33,11 @@ def test_user_metadata_fields():
         cdn_path="/some/path/to/my.rpm",
         cdn_published=datetime.datetime(2021, 4, 1, 1, 8, 26),
     )
+
+
+def test_repr_no_defaults():
+    """Verify that repr only shows those fields with non-default values."""
+
+    u = RpmUnit(name="bash", version="4.0", release="1", arch="x86_64")
+
+    assert repr(u) == "RpmUnit(name='bash', version='4.0', release='1', arch='x86_64')"


### PR DESCRIPTION
The default attrs-generated \_\_repr\_\_ will log every single field, even
those which are optional and are matching their default value.

It's friendlier to include only those non-default fields. This will
improve the logging quite a bit in some cases. For example, it's the
difference between:

    # Old behavior:
    ErratumUnit(id='RHBA-2022:72688', version=None, status=None,
      updated=None, issued=None, description=None, pushcount=None,
      reboot_suggested=None, from_=None, rights=None, title=None,
      severity=None, release=None, type=None, solution=None,
      summary=None, content_types=None, references=None, pkglist=None,
      content_type_id=u'erratum', repository_memberships=None,
      unit_id=None)

    # New behavior:
    ErratumUnit(id='RHBA-2022:72688')

This also helps make log-based testing more stable, as adding new fields
onto Pulp objects will no longer change how every object appears in
logs.