### PR TITLE
Make TaskFailedException include error details by default

### DIFF
--- a/pubtools/pulplib/_impl/client/errors.py
+++ b/pubtools/pulplib/_impl/client/errors.py
@@ -13,7 +13,7 @@ class TaskFailedException(PulpException):
         Error details may be accessed from the task.
         """
 
-        super(TaskFailedException, self).__init__("Task %s failed" % task.id)
+        super(TaskFailedException, self).__init__(task.error_details)
 
 
 class MissingTaskException(PulpException):

--- a/pubtools/pulplib/_impl/client/retry.py
+++ b/pubtools/pulplib/_impl/client/retry.py
@@ -49,12 +49,22 @@ class PulpRetryPolicy(RetryPolicy):
         exception = future.exception()
         LOG.warning(
             "Retrying due to error: %s [%d/%d]%s",
-            exception,
+            self._message(exception),
             attempt,
             self._max_attempts,
             self._traceback(exception),
             extra={"event": {"type": "pulp-retry"}},
         )
+
+    def _message(self, exception):
+        if isinstance(exception, TaskFailedException):
+            # For the retry logs, don't include the full details on the task.
+            # It's too verbose to include inline.
+            # It can be logged separately or if all retries are exhausted.
+            return "Task %s failed" % exception.task.id
+
+        # Anything else uses default stringification.
+        return str(exception)
 
     def _traceback(self, exception):
         out = ""

--- a/tests/repository/test_publish.py
+++ b/tests/repository/test_publish.py
@@ -191,7 +191,13 @@ def test_publish_fail(fast_poller, requests_mocker, client):
 
     requests_mocker.post(
         "https://pulp.example.com/pulp/api/v2/tasks/search/",
-        json=[{"task_id": "task1", "state": "error"}],
+        json=[
+            {
+                "task_id": "task1",
+                "state": "error",
+                "error": {"code": "ABC00123", "description": "Simulated error"},
+            }
+        ],
     )
 
     publish_f = repo.publish()
@@ -202,7 +208,7 @@ def test_publish_fail(fast_poller, requests_mocker, client):
 
     # The exception should have a reference to the task which failed
     assert error.value.task.id == "task1"
-    assert "Task task1 failed" in str(error.value)
+    assert "Pulp task [task1] failed: ABC00123: Simulated error" in str(error.value)
 
 
 def test_publish_broken_response(fast_poller, requests_mocker, client):


### PR DESCRIPTION
Currently, if a Pulp task fails and propagates upwards to generic
code which catches and logs all exceptions, the logs would show
something like this level of detail:

    Task 91e3fc2d-de01-4ddd-a236-b2179d3bba0f failed

More details are available, including the Pulp traceback, but
you'd have to explicitly catch TaskFailedException and look at
task.error_details to get at them. In practice nobody is doing that,
so the details end up missing from logs.

It makes more sense to include all the details by default, so let's
start doing that. An exception to this is the case of a retry; we'll
keep the logs terse in that case, until all retries are exhausted.