### PR TITLE
Fix upload_comps_xml omitting false 'default' fields [RHELDST-10597]

### DIFF
--- a/pubtools/pulplib/_impl/comps.py
+++ b/pubtools/pulplib/_impl/comps.py
@@ -217,8 +217,7 @@ class CompsParser(object):
 
         option = {"group": self.current_buf}
 
-        if (attrs.get("default") or "").lower() == "true":
-            option["default"] = True
+        option["default"] = (attrs.get("default") or "").lower() == "true"
 
         self.current_unit.setdefault("options", []).append(option)
 

--- a/tests/comps/test_comps_parse.py
+++ b/tests/comps/test_comps_parse.py
@@ -95,7 +95,10 @@ def test_can_parse_units(data_path):
         },
         "display_order": None,
         "group_ids": ["networkmanager-submodules", "standard"],
-        "options": [{"default": True, "group": "xmonad"}, {"group": "xmonad-mate"}],
+        "options": [
+            {"default": True, "group": "xmonad"},
+            {"default": False, "group": "xmonad-mate"},
+        ],
     }
 
     assert units[5] == {
@@ -109,7 +112,7 @@ def test_can_parse_units(data_path):
         },
         "display_order": 22,
         "group_ids": ["input-methods", "multimedia"],
-        "options": [{"group": "libreoffice"}],
+        "options": [{"default": False, "group": "libreoffice"}],
     }
 
     assert units[6] == {

--- a/tests/repository/test_upload_comps.py
+++ b/tests/repository/test_upload_comps.py
@@ -152,7 +152,10 @@ def test_upload_comps_xml(client, requests_mocker):
             "translated_name": {"af": "Basiese werkskerm"},
             "description": "X Window System with a choice of window manager.",
             "group_ids": ["networkmanager-submodules", "standard"],
-            "options": [{"group": "xmonad", "default": True}, {"group": "xmonad-mate"}],
+            "options": [
+                {"group": "xmonad", "default": True},
+                {"group": "xmonad-mate", "default": False},
+            ],
             "repo_id": "repo1",
         },
         {


### PR DESCRIPTION
The logic here was to include a 'default' field within options in the
generated units only if the value was True.

That causes a crash during publish in Pulp, because the Pulp code at [1]
unconditionally assumes that every option has a 'default' field and will
raise a KeyError otherwise. Fix it to be compatible with Pulp's
expectation.

This is not a new bug, but was recently found as this code has been
tested with more realistic data.

[1] https://github.com/pulp/pulp_rpm/blob/pulp-rpm-2.14.3-1/plugins/pulp_rpm/plugins/distributors/yum/metadata/package.py#L162