### PR TITLE
ci: add test timeouts & verbose args for debugging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,10 @@ commands=pidiff pubtools-pulplib . pubtools.pulplib {posargs}
 deps=
 	-rtest-requirements.txt
 	pytest-cov
+	pytest-timeout
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov-report=xml --cov=pubtools --cov-fail-under=100 {posargs}
+	pytest -svv --timeout 60 --cov-report=html --cov-report=xml --cov=pubtools --cov-fail-under=100 {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
The test suite in this repo is occassionally hanging when CI runs. The
cause of the hang is unclear. Let's try applying a per-test timeout and
increasing verbosity of the tests, so that the next time it happens
there's hopefully some useful evidence left behind.