### PR TITLE
Add fields & API for updating product_versions

### DIFF
--- a/pubtools/pulplib/_impl/model/attr.py
+++ b/pubtools/pulplib/_impl/model/attr.py
@@ -10,6 +10,9 @@ PULP2_FIELD = "_pubtools.pulplib.pulp2_field"
 # attr metadata private key indicating whether a field is part of the unit_key.
 PULP2_UNIT_KEY = "_pubtools.pulplib.pulp2_unit_key"
 
+# attr metadata private key indicating whether a field is considered mutable.
+PULP2_MUTABLE = "_pubtools.pulplib.pulp2_mutable"
+
 # attr metadata private key for converting from a pulp2 representation and a Python
 # object.
 # Why not using attr.ib built-in 'converter'?  Because that makes it public API,
@@ -26,6 +29,7 @@ def pulp_attrib(
     pulp_field=None,
     pulp_py_converter=None,
     py_pulp_converter=None,
+    mutable=False,
     unit_key=None,
     **kwargs
 ):
@@ -47,6 +51,9 @@ def pulp_attrib(
 
     if unit_key is not None:
         metadata[PULP2_UNIT_KEY] = unit_key
+
+    if mutable:
+        metadata[PULP2_MUTABLE] = True
 
     if "type" in kwargs:
         # As a convenience, you may define string types as type=str

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.29.0",
+    version="2.30.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_update_repository.py
+++ b/tests/client/test_update_repository.py
@@ -1,0 +1,55 @@
+import pytest
+import datetime
+
+from pubtools.pulplib import FileRepository
+
+
+def test_can_update_repo(requests_mocker, client):
+    requests_mocker.put(
+        "https://pulp.example.com/pulp/api/v2/repositories/my-repo/",
+        text="null",
+        headers={"Content-Type": "application/json"},
+    )
+
+    repo = FileRepository(
+        id="my-repo", eng_product_id=123, product_versions=["1.0", "1.1"]
+    )
+
+    update_f = client.update_repository(repo)
+
+    # It should succeed.
+    update_f.result()
+
+    # It should have done a single request.
+    assert len(requests_mocker.request_history) == 1
+
+    req = requests_mocker.request_history[0]
+
+    # Should have been a PUT to the appropriate API.
+    assert req.method == "PUT"
+    assert req.url == "https://pulp.example.com/pulp/api/v2/repositories/my-repo/"
+
+    # Should have requested exactly this update - only the mutable notes
+    assert req.json() == {
+        "delta": {
+            "notes": {
+                # Note the serialization into embedded JSON here.
+                "product_versions": '["1.0","1.1"]'
+            }
+        }
+    }
+
+
+def test_update_repo_fails(requests_mocker, client):
+    requests_mocker.put(
+        "https://pulp.example.com/pulp/api/v2/repositories/my-repo/", status_code=400
+    )
+
+    repo = FileRepository(
+        id="my-repo", eng_product_id=123, product_versions=["1.0", "1.1"]
+    )
+
+    update_f = client.update_repository(repo)
+
+    # It should fail, since the HTTP request failed.
+    assert "400 Client Error" in str(update_f.exception())

--- a/tests/fake/test_fake_update_repository.py
+++ b/tests/fake/test_fake_update_repository.py
@@ -1,0 +1,51 @@
+import datetime
+import pytest
+import attr
+
+from pubtools.pulplib import FakeController, FileUnit, FileRepository
+
+
+def test_update_missing_repo():
+    controller = FakeController()
+    client = controller.client
+
+    # Try to update something which is previously unknown to the client.
+    update_f = client.update_repository(FileRepository(id="whatever"))
+
+    # It should fail telling us the repo doesn't exist
+    assert "repository not found: whatever" in str(update_f.exception())
+
+
+def test_can_update_repo():
+    controller = FakeController()
+
+    controller.insert_repository(
+        FileRepository(id="repo", product_versions=["a", "b", "c"])
+    )
+
+    client = controller.client
+
+    # Should be able to get the repo.
+    repo = client.get_repository("repo").result()
+
+    # Let's try putting it back. Note we try changing both some mutable
+    # and immutable fields here.
+    update_f = client.update_repository(
+        attr.evolve(repo, eng_product_id=123, product_versions=["d", "b"])
+    )
+
+    # The update should succeed (and return None)
+    assert update_f.result() is None
+
+    # Try getting the same repo back.
+    repo_updated = client.get_repository("repo").result()
+
+    # It should be equal to this:
+    assert repo_updated == FileRepository(
+        id="repo",
+        # product_versions is mutable, so it's what we asked for (with
+        # values canonicalized by sorting)
+        product_versions=["b", "d"],
+        # eng_product_id is not mutable, so that update was ignored
+        eng_product_id=None,
+    )

--- a/tests/repository/test_yum_repository.py
+++ b/tests/repository/test_yum_repository.py
@@ -80,6 +80,48 @@ def test_populate_attrs():
     assert repo.ubi_config_version == "fake_ubi_config_version"
 
 
+def test_productid_attrs():
+    """All attributes relating to productid are correctly parsed from repo notes."""
+
+    repo = Repository.from_data(
+        {
+            "id": "my-repo",
+            "notes": {
+                "_repo-type": "rpm-repo",
+                "arch": "x86_64",
+                "product_versions": '["1.4", "1.100", "1.2"]',
+                "platform_full_version": "whatever",
+                "eng_product": "123",
+            },
+            "distributors": [],
+        }
+    )
+
+    assert repo.arch == "x86_64"
+    assert repo.eng_product_id == 123
+    assert repo.platform_full_version == "whatever"
+
+    # Note the version-aware sorting: 1.100 is larger than 1.4
+    assert repo.product_versions == ["1.2", "1.4", "1.100"]
+
+
+def test_product_versions_unusual_attrs():
+    """Odd values in product_versions are tolerated."""
+
+    repo = Repository.from_data(
+        {
+            "id": "my-repo",
+            "notes": {
+                "_repo-type": "rpm-repo",
+                "product_versions": '["1.4", 234, "1.100", "not numeric"]',
+            },
+            "distributors": [],
+        }
+    )
+
+    assert repo.product_versions == ["1.100", "1.4", "234", "not numeric"]
+
+
 def test_related_repositories(client, requests_mocker):
     """test Repository.get_*_repository returns expected objects"""
 


### PR DESCRIPTION
In the legacy tooling, when a productid is uploaded into a repository,
the product_versions field will be updated across various repos. This
commit adds everything needed to pubtools-pulplib for the same behavior
to be implemented using this library:

- a few trivial repo fields were added (e.g. arch) which are used for
  searching repos for update

- the product_versions field was added

- an update_repository method was added, which allows updating
  any mutable field on a repo. The set of mutable fields is set
  conservatively, starting with only product_versions, since most
  of the fields are managed elsewhere and we don't have plans to
  change that currently.

- the design of update_repository (update mutable fields on a repo)
  closely follows the similar method update_content (update mutable
  fields on a unit).