### PR TITLE
Add support for toggling RPM signature filtering in copy

### DIFF
--- a/docs/api/client.rst
+++ b/docs/api/client.rst
@@ -4,6 +4,8 @@ API: client
 .. autoclass:: pubtools.pulplib.Client
    :members:
 
+.. autoclass:: pubtools.pulplib.CopyOptions
+   :members:
 
 Errors
 ------

--- a/pubtools/pulplib/__init__.py
+++ b/pubtools/pulplib/__init__.py
@@ -1,4 +1,4 @@
-from ._impl.client import Client, PulpException, TaskFailedException
+from ._impl.client import Client, PulpException, TaskFailedException, CopyOptions
 from ._impl.criteria import Criteria, Matcher
 from ._impl.page import Page
 from ._impl.model import (

--- a/pubtools/pulplib/_impl/client/__init__.py
+++ b/pubtools/pulplib/_impl/client/__init__.py
@@ -1,2 +1,2 @@
-from .client import Client
+from .client import Client, CopyOptions
 from .errors import PulpException, TaskFailedException

--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -17,12 +17,14 @@ from ..criteria import Criteria
 from ..model import (
     Repository,
     FileRepository,
+    YumRepository,
     MaintenanceReport,
     Distributor,
     Unit,
     Task,
 )
 from ..log import TimedLogger
+from ..util import dict_put
 from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
@@ -30,6 +32,7 @@ from . import retry
 from .humanize_compat import naturalsize
 
 from .ud_mappings import compile_ud_mappings
+from .copy import CopyOptions
 
 
 LOG = logging.getLogger("pubtools.pulplib")
@@ -300,7 +303,9 @@ class Client(object):
             )
         )
 
-    def copy_content(self, from_repository, to_repository, criteria=None):
+    def copy_content(
+        self, from_repository, to_repository, criteria=None, options=CopyOptions()
+    ):
         """Copy content from one repository to another.
 
         Args:
@@ -314,6 +319,13 @@ class Client(object):
                 A criteria object used to find units for copy.
                 If None, all units in the source repo will be copied.
 
+            options (:class:`~pubtools.pulplib.CopyOptions`)
+                Options influencing the copy.
+
+                Some options may be specific to certain repository and content
+                types. Options which are not applicable to this copy will be
+                ignored.
+
         Returns:
             Future[list[:class:`~pubtools.pulplib.Task`]]
                 A future which is resolved when the copy completes.
@@ -323,9 +335,27 @@ class Client(object):
                 typically will have only a subset of available fields.
 
         .. versionadded:: 2.17.0
+
+        .. versionadded:: 2.30.0
+            Added the ``options`` argument.
         """
+
+        raw_options = {}
+
+        if (
+            isinstance(to_repository, YumRepository)
+            and options.require_signed_rpms is not None
+        ):
+            dict_put(
+                raw_options,
+                "override_config.require_signature",
+                options.require_signed_rpms,
+            )
+
         return f_proxy(
-            self._do_associate(from_repository.id, to_repository.id, criteria)
+            self._do_associate(
+                from_repository.id, to_repository.id, criteria, raw_options
+            )
         )
 
     def update_content(self, unit):
@@ -662,7 +692,7 @@ class Client(object):
             self._do_request, method="POST", url=url, json=body
         )
 
-    def _do_associate(self, src_repo_id, dest_repo_id, criteria=None):
+    def _do_associate(self, src_repo_id, dest_repo_id, criteria=None, raw_options=None):
         url = os.path.join(
             self._url, "pulp/api/v2/repositories/%s/actions/associate/" % dest_repo_id
         )
@@ -674,6 +704,8 @@ class Client(object):
             body["criteria"]["type_ids"] = pulp_search.type_ids
         if pulp_search.filters:
             body["criteria"]["filters"] = {"unit": pulp_search.filters}
+
+        body.update(raw_options or {})
 
         LOG.debug("Submitting %s associate: %s", url, body)
 

--- a/pubtools/pulplib/_impl/client/copy.py
+++ b/pubtools/pulplib/_impl/client/copy.py
@@ -1,0 +1,21 @@
+from .. import compat_attr as attr
+
+optional = attr.validators.optional
+instance_of = attr.validators.instance_of
+
+
+@attr.s(kw_only=True, frozen=True, repr=True)
+class CopyOptions(object):
+    """Options influencing a call to
+    :meth:`~pubtools.pulplib.Client.copy_content`.
+    """
+
+    require_signed_rpms = attr.ib(
+        type=bool, default=None, validator=optional(instance_of(bool))
+    )
+    """Whether to require signatures on all RPMs in the copy.
+
+    In order to copy unsigned RPMs between repositories, it is generally
+    necessary to set this flag to ``False``. Unsigned RPMs may otherwise
+    be silently omitted from the copy.
+    """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.29.0",
+    version="2.30.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",


### PR DESCRIPTION
When copying RPMs between repos, Pulp may enforce a signature check on
the RPMs, according to repo-specific config.

It is sometimes necessary to override this config during a copy, e.g. to
temporarily allow unsigned RPMs into a repo. Add the necessary API to
control this flag.