### PR TITLE
Bump black version and reformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 026c81b83454f176a9f9253cbfb70be2c159d822
+  - repo: https://github.com/ambv/black
+    rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.6
-
+      language_version: python3.8

--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -48,7 +48,6 @@ if ATTR_VERSION < (18, 1):  # pragma: no cover
             out[field.name] = field
         return out
 
-
 else:
     fields_dict = attr.fields_dict
 

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -706,7 +706,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
     def _next_task_id(self):
         with self._lock:
-            next_raw_id = self._uuidgen.randint(0, 2 ** 128)
+            next_raw_id = self._uuidgen.randint(0, 2**128)
         return str(uuid.UUID(int=next_raw_id))
 
     def _next_request_id(self):

--- a/pubtools/pulplib/_impl/fake/units.py
+++ b/pubtools/pulplib/_impl/fake/units.py
@@ -41,7 +41,7 @@ class UnitMaker(object):
     def next_unit_id(self):
         with self._lock:
             while True:
-                next_raw_id = self._uuidgen.randint(0, 2 ** 128)
+                next_raw_id = self._uuidgen.randint(0, 2**128)
                 if next_raw_id not in self._seen_unit_ids:
                     break
 

--- a/tests/comps/test_comps_parse.py
+++ b/tests/comps/test_comps_parse.py
@@ -4,6 +4,10 @@ import os
 
 from pubtools.pulplib._impl.comps import units_for_xml
 
+# Don't use autoformatting in this file because we use u'' string literals
+# at least until py2 support is dropped, and black wants to remove them...
+# fmt: off
+
 
 def test_can_parse_units(data_path):
     """units_for_xml parses typical comps.xml data correctly."""

--- a/tests/repository/test_upload.py
+++ b/tests/repository/test_upload.py
@@ -112,9 +112,9 @@ def test_upload_file(client, requests_mocker, tmpdir, caplog, fast_timed_logger)
     # 4th call should be import, check if right unit_key's passed
     import_request = requests_mocker.request_history[3].json()
     import_unit_key = {
-        u"name": somefile.basename,
-        u"checksum": u"fad3fc1e6d583b2003ec0a5273702ed8fcc2504271c87c40d9176467ebe218cb",
-        u"size": 29,
+        "name": somefile.basename,
+        "checksum": "fad3fc1e6d583b2003ec0a5273702ed8fcc2504271c87c40d9176467ebe218cb",
+        "size": 29,
     }
     assert import_request["unit_key"] == import_unit_key
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==20.8b1
+	black==22.3.0
 	pylint==2.7.2
 commands=
 	black --check .


### PR DESCRIPTION
A version bump is needed as the older version has become uninstallable,
apparently due to using some private API from click module.