### PR TITLE
Make ModulemdUnit and ModulemdDefaultUnit profiles immutable

### DIFF
--- a/pubtools/pulplib/_impl/compat_frozendict.py
+++ b/pubtools/pulplib/_impl/compat_frozendict.py
@@ -1,0 +1,7 @@
+import sys
+
+if sys.version_info >= (3, 0):
+    # pylint: disable=unused-import,no-name-in-module
+    from frozendict.core import frozendict
+else:
+    frozendict = dict  # pragma: no cover

--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -5,6 +5,7 @@ import six
 from frozenlist2 import frozenlist
 
 from .attr import PULP2_PY_CONVERTER
+from ..compat_frozendict import frozendict
 
 # Work around http://bugs.python.org/issue7980 which is closed "Won't Fix"
 # for python2:
@@ -81,3 +82,17 @@ def frozenlist_or_none_converter(obj, map_fn=(lambda x: x)):
 frozenlist_or_none_sorted_converter = functools.partial(
     frozenlist_or_none_converter, map_fn=lambda x: sorted(set(x))
 )
+
+
+def frozendict_or_none_converter(obj):
+    # Convert object and values to immutable structures.
+    # Skip convert if the obj is already frozendict.
+    # This happens when the class containing the value is copied (e.g: with attr.evolve).
+    if obj is not None and not isinstance(obj, frozendict):
+        for (key, value) in obj.items():
+            if isinstance(value, list):
+                obj[key] = frozenlist_or_none_converter(value)
+            if isinstance(value, dict):
+                obj[key] = frozendict_or_none_converter(value)
+        return frozendict(obj)
+    return obj

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -4,8 +4,12 @@ from .base import Unit, unit_type, schemaless_init
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..convert import frozenlist_or_none_converter, frozenlist_or_none_sorted_converter
-from ..validate import optional_list_of
+from ..convert import (
+    frozenlist_or_none_converter,
+    frozenlist_or_none_sorted_converter,
+    frozendict_or_none_converter,
+)
+from ..validate import optional_list_of, optional_dict
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -128,7 +132,13 @@ class ModulemdUnit(Unit):
 
     """
 
-    profiles = pulp_attrib(type=dict, pulp_field="profiles", default=None)
+    profiles = pulp_attrib(
+        type=dict,
+        pulp_field="profiles",
+        default=None,
+        validator=optional_dict,
+        converter=frozendict_or_none_converter,
+    )
     """The profiles of this modulemd unit."""
 
     dependencies = pulp_attrib(

--- a/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd_defaults.py
@@ -2,7 +2,9 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..convert import frozenlist_or_none_sorted_converter
+from ...compat_frozendict import frozendict
+from ..convert import frozenlist_or_none_sorted_converter, frozendict_or_none_converter
+from ..validate import optional_dict
 
 
 @unit_type("modulemd_defaults")
@@ -22,7 +24,13 @@ class ModulemdDefaultsUnit(Unit):
     stream = pulp_attrib(type=str, pulp_field="stream", default=None)
     """The stream of this modulemd defaults unit"""
 
-    profiles = pulp_attrib(type=dict, pulp_field="profiles", default=None)
+    profiles = pulp_attrib(
+        type=frozendict,
+        pulp_field="profiles",
+        default=None,
+        validator=optional_dict,
+        converter=frozendict_or_none_converter,
+    )
     """The profiles of this modulemd defaults unit."""
 
     content_type_id = pulp_attrib(

--- a/pubtools/pulplib/_impl/model/validate.py
+++ b/pubtools/pulplib/_impl/model/validate.py
@@ -6,6 +6,7 @@ instance_of = validators.instance_of
 
 optional_str = instance_of(six.string_types + (type(None),))
 optional_bool = instance_of((bool, type(None)))
+optional_dict = instance_of((dict, type(None)))
 
 # This is a workaround for the absence of deep_iterable on older attr.
 # Drop it when the legacy environment is no longer required.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ PyYAML
 jsonschema
 attrs
 frozenlist2
+frozendict
 pubtools>=0.3.0
 humanize

--- a/tests/model/test_modulemd_model.py
+++ b/tests/model/test_modulemd_model.py
@@ -1,0 +1,88 @@
+import sys
+import pytest
+
+from pubtools.pulplib import (
+    ModulemdUnit,
+    ModulemdDefaultsUnit,
+)
+from pubtools.pulplib._impl.compat_frozendict import frozendict
+from frozenlist2 import frozenlist
+
+
+def get_test_values():
+
+    default_unit = ModulemdDefaultsUnit(
+        unit_id="md_unit_id",
+        name="md_unit_name",
+        repo_id="md_unit_repo",
+        profiles={"1.0": ["default"]},
+    )
+
+    md_unit = ModulemdUnit(
+        unit_id="unit_id",
+        name="name",
+        stream="1.0",
+        version=1,
+        context="context",
+        arch="x86_64",
+        profiles={
+            "default": {
+                "description": "Default description",
+                "rpms": ["rpm"],
+            },
+        },
+    )
+    return default_unit, md_unit
+
+
+@pytest.mark.xfail(
+    sys.version_info < (3, 0),
+    reason="The conversion function checks if the value is already a frozendict, which is just "
+    "dict in python2, so profiles and the contents wont be converted",
+)
+def test_convert_profile_value():
+    """Profile and the values it contains should be immutable"""
+
+    default_unit, md_unit = get_test_values()
+
+    assert isinstance(default_unit.profiles, frozendict)
+    assert isinstance(default_unit.profiles["1.0"], frozenlist)
+    assert isinstance(md_unit.profiles, frozendict)
+    assert isinstance(md_unit.profiles["default"], frozendict)
+    assert isinstance(md_unit.profiles["default"]["rpms"], frozenlist)
+
+
+@pytest.mark.xfail(
+    sys.version_info < (3, 0),
+    reason="Frozendict falls back to the default dict for Python2, so wont have a hash",
+)
+def test_profiles_have_hash():
+    """If two objects are equal, then they must have the same hashcode"""
+    default_unit_1, md_unit_1 = get_test_values()
+    default_unit_2, md_unit_2 = get_test_values()
+
+    assert hash(default_unit_1) == hash(default_unit_2)
+    assert hash(md_unit_1) == hash(md_unit_2)
+
+
+@pytest.mark.xfail(
+    sys.version_info < (3, 0),
+    reason="Frozendict falls back to the default dict for Python2, so wont throw exceptions",
+)
+def test_fail_on_modify_profiles():
+    """Should fail when the profile attribute is modified"""
+    default_unit, md_unit = get_test_values()
+    with pytest.raises(AttributeError):
+        default_unit.profiles.clear()
+
+    with pytest.raises(TypeError):
+        default_unit.profiles["1.0"] = ["modify"]
+
+    with pytest.raises(NotImplementedError):
+        default_unit.profiles["1.0"].append("modify")
+
+    with pytest.raises(TypeError):
+        md_unit.profiles["default"] = {}
+
+    with pytest.raises(TypeError):
+        md_unit.profiles["default"]["description"] = "modify"


### PR DESCRIPTION
The profiles value for ModulemdUnit and ModulemdDefaultUnit was a dict
type, which ment the value was mutable. This made it dangerous to use
these classes in threads and to hash them. This change replaces the dict
type with frozendict, which is an implementation of an immutable
dictionary. Frozendict is only implemented for python3 so naturally
the change will only be available in python3. We assume that people
using this library will test their code against python3 so it will
catch any cases where they try to modify a value in profiles.
