### PR TITLE
Make client thread count configurable by public API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.30.0",
+    version="2.31.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_client_threadcount.py
+++ b/tests/client/test_client_threadcount.py
@@ -1,0 +1,46 @@
+import pytest
+
+from concurrent.futures import ThreadPoolExecutor
+
+from pubtools.pulplib import Client
+
+
+@pytest.fixture
+def spy_requested_threads(monkeypatch):
+    """This fixture intercepts all ThreadPoolExecutor.__init__ calls
+    to spy on the number of requested threads.
+
+    Yields a list which will gain a new element every time an executor
+    is created, the element being the executor's max_workers parameter.
+    """
+
+    requested_threads = []
+    executor_ctor = ThreadPoolExecutor.__init__
+
+    def spy_requested_threads(*args, **kwargs):
+        requested_threads.append(kwargs.get("max_workers"))
+        return executor_ctor(*args, **kwargs)
+
+    monkeypatch.setattr(ThreadPoolExecutor, "__init__", spy_requested_threads)
+
+    yield requested_threads
+
+
+def test_at_least_one_thread(spy_requested_threads):
+    """Client always enforces at least one thread (per pool)"""
+
+    with Client("https://pulp.example.com/", threads=-5) as client:
+        pass
+
+    # Everything should have used a single thread each
+    assert set(spy_requested_threads) == set([1])
+
+
+def test_threads(spy_requested_threads):
+    """Caller's requested 'threads' are passed into any internal ThreadPoolExecutors."""
+
+    with Client("https://pulp.example.com/", threads=3) as client:
+        pass
+
+    # Everything should have used the requested number of threads
+    assert set(spy_requested_threads) == set([3])


### PR DESCRIPTION
Thread counts used by pulplib.Client have already been configurable by
env vars as a hidden feature. I'd like to promote this to public API
because I now have a case where a single process should use more than
one instance of Client at once. In that case, a single env var is not
a convenient way to configure the thread count, as you probably want to
use a lower thread count than usual if you're creating more clients.

The details of how the client manages its work internally shouldn't be
baked into the API, so there is just one option covering the client's
multiple thread pools rather than an option per pool.