### PR TITLE
refactor: support multiple fakes with shared state

### DIFF
--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -1,6 +1,4 @@
 import random
-import uuid
-import threading
 import hashlib
 import json
 import re
@@ -20,7 +18,6 @@ from pubtools.pulplib import (
     Repository,
     Distributor,
     Unit,
-    FileUnit,
     RpmUnit,
     MaintenanceReport,
     CopyOptions,
@@ -46,50 +43,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
     # written against pubtools.pulplib.Client should be able to work with
     # an instance of this class swapped in.
     _PAGE_SIZE = 3
-    _DEFAULT_TYPE_IDS = [
-        "distribution",
-        "drpm",
-        "erratum",
-        "iso",
-        "modulemd_defaults",
-        "modulemd",
-        "package_category",
-        "package_environment",
-        "package_group",
-        "package_langpacks",
-        "repository",
-        "rpm",
-        "srpm",
-        "yum_repo_metadata_file",
-    ]
 
-    def __init__(self):
-        self._repositories = []
-
-        # Similar to a real Pulp server, units are stored through a "unit key"
-        # layer of indirection:
-        # - repos contain unit keys
-        # - a unit key refers to one (and only one) unit
-        #
-        # By storing data in this way, we ensure we have similar behavior and
-        # constraints as a real Pulp server, e.g. cannot store two different units
-        # which would have the same key; updating a unit referenced from multiple repos
-        # effectively updates it in all repos at once; etc.
-        self._repo_unit_keys = {}
-        self._units_by_key = {}
-
-        self._publish_history = []
-        self._upload_history = []
-        self._uploads_pending = {}
-        self._sync_history = []
-        self._tasks = []
-        self._maintenance_report = None
-        self._type_ids = self._DEFAULT_TYPE_IDS[:]
-        self._seen_unit_ids = set()
-        self._lock = threading.RLock()
-        self._uuidgen = random.Random()
-        self._uuidgen.seed(0)
-        self._unitmaker = units.UnitMaker(self._seen_unit_ids)
+    def __init__(self, state):
+        self._state = state
         self._shutdown = False
 
     def __enter__(self):
@@ -97,90 +53,6 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
     def __exit__(self, *_args, **_kwargs):
         self._shutdown = True
-
-    @property
-    def _all_units(self):
-        # Get all units in all repos.
-        #
-        # Cannot be used to modify units.
-        return list(self._units_by_key.values())
-
-    def _repo_units(self, repo_id):
-        # Get all units in a particular repo.
-        #
-        # Cannot be used to modify units.
-        out = []
-        for key in self._repo_unit_keys.get(repo_id) or []:
-            out.append(self._units_by_key[key])
-        return out
-
-    def _remove_unit(self, repo_id, unit):
-        # Remove a single unit from a repository.
-        unit_key = units.make_unit_key(unit)
-
-        # Ensure unit is no longer referenced from the repo
-        self._repo_unit_keys[repo_id].remove(unit_key)
-
-        # Ensure repo ID is no longer in memberships
-        new_repos = [id for id in unit.repository_memberships if id != repo_id]
-        self._units_by_key[unit_key] = attr.evolve(
-            unit, repository_memberships=new_repos
-        )
-
-    def _remove_clashing_units(self, repo_id, unit):
-        # In preparation for adding 'unit' into a repo, remove any existing
-        # units from that repo which would clash, in a compatible manner as Pulp.
-        #
-        # Currently this is a special case only for File units: although their
-        # unit_key consists of more than just 'name' making it technically possible
-        # to have multiple files with the same name in a repo, Pulp has special logic
-        # to try to prevent this, so we do the same here.
-        if isinstance(unit, FileUnit):
-            for existing in self._repo_units(repo_id):
-                if isinstance(existing, FileUnit) and existing.path == unit.path:
-                    self._remove_unit(repo_id, existing)
-
-    def _insert_repo_units(self, repo_id, units_to_add):
-        # Insert an iterable of units into a specific repo.
-        #
-        # If a unit with the same key exists in multiple repos, this will update
-        # matching units across *all* of those repos - same as a real pulp server.
-
-        repo_unit_keys = self._repo_unit_keys.setdefault(repo_id, set())
-        memberships = []
-        if repo_id is not None:
-            memberships.append(repo_id)
-
-        for unit in units_to_add:
-            # Always consume a unit ID from the unitmaker even if we don't actually
-            # need it. The point of this is to ensure that if you serialize/deserialize
-            # a fake client, e.g. as done in pubtools-pulp, then the freshly created
-            # client will not try to use the same sequence of IDs as already used in
-            # the units we've just deserialized.
-            unit_id = self._unitmaker.next_unit_id()
-
-            if not unit.unit_id:
-                unit = attr.evolve(unit, unit_id=unit_id)
-
-            self._seen_unit_ids.add(unit.unit_id)
-
-            # Unit belongs to the repo we're adding it to.
-            # Note: this may be further merged with an existing unit's
-            # repository_memberships a few lines below.
-            unit = attr.evolve(
-                unit,
-                repository_memberships=(unit.repository_memberships or [])
-                + memberships,
-            )
-
-            if repo_id is not None:
-                # Unit might be replacing earlier units in same repo.
-                self._remove_clashing_units(repo_id, unit)
-
-            unit_key = units.make_unit_key(unit)
-            old_unit = self._units_by_key.get(unit_key)
-            self._units_by_key[unit_key] = units.merge_units(old_unit, unit)
-            repo_unit_keys.add(unit_key)
 
     def _ensure_alive(self):
         if self._shutdown:
@@ -203,7 +75,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         search_for_criteria(criteria, Repository)
 
         try:
-            for repo in self._repositories:
+            for repo in self._state.repositories[:]:
                 if match_object(criteria, repo):
                     repos.append(self._attach_repo(repo))
         except Exception as ex:  # pylint: disable=broad-except
@@ -227,7 +99,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         # applies to the fake.
         prepared_search = search_for_criteria(criteria, Unit)
 
-        available_type_ids = set(self._type_ids)
+        available_type_ids = set(self._state.type_ids)
         missing_type_ids = set(prepared_search.type_ids or []) - available_type_ids
         if missing_type_ids:
             return f_return_error(
@@ -237,7 +109,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
                 )
             )
 
-        for unit in self._all_units:
+        for unit in self._state.all_units:
             if (
                 prepared_search.type_ids
                 and unit.content_type_id not in prepared_search.type_ids
@@ -272,38 +144,39 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         # in repository_memberships from now on.
         found = [attr.evolve(unit, repository_memberships=[to_id]) for unit in found]
 
-        # Now put the found units into the destination repo.
-        # Any kind of merging or replacing of units is handled within this step.
-        self._insert_repo_units(to_id, found)
+        with self._state.lock:
+            # Now put the found units into the destination repo.
+            # Any kind of merging or replacing of units is handled within this step.
+            self._state.insert_repo_units(to_id, found)
 
-        # Arbitrarily limit the number of units included per task. The point is
-        # to enforce that the caller doesn't expect any specific number of tasks.
-        tasks = []
-        while found:
-            next_batch = found[:5]
-            found = found[5:]
-            tasks.append(
-                Task(
-                    id=self._next_task_id(),
-                    repo_id=from_id,
-                    completed=True,
-                    succeeded=True,
-                    units=units.with_key_only(next_batch),
+            # Arbitrarily limit the number of units included per task. The point is
+            # to enforce that the caller doesn't expect any specific number of tasks.
+            tasks = []
+            while found:
+                next_batch = found[:5]
+                found = found[5:]
+                tasks.append(
+                    Task(
+                        id=self._state.next_task_id(),
+                        repo_id=from_id,
+                        completed=True,
+                        succeeded=True,
+                        units=units.with_key_only(next_batch),
+                    )
                 )
-            )
 
-        if not tasks:
-            # This indicates that nothing was found at all.
-            # That's fine, just return a task with empty units.
-            tasks.append(
-                Task(
-                    id=self._next_task_id(),
-                    repo_id=from_id,
-                    completed=True,
-                    succeeded=True,
-                    units=[],
+            if not tasks:
+                # This indicates that nothing was found at all.
+                # That's fine, just return a task with empty units.
+                tasks.append(
+                    Task(
+                        id=self._state.next_task_id(),
+                        repo_id=from_id,
+                        completed=True,
+                        succeeded=True,
+                        units=[],
+                    )
                 )
-            )
 
         return f_proxy(f_return(tasks))
 
@@ -313,53 +186,57 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         if not unit.unit_id:
             raise ValueError("unit_id missing on call to update_content()")
 
-        # The unit has to exist.
-        existing_unit = None
-        for candidate in self._all_units:
-            if (
-                candidate.content_type_id == unit.content_type_id
-                and candidate.unit_id == unit.unit_id
-            ):
-                existing_unit = candidate
-                break
-        else:
-            return f_return_error(PulpException("unit not found: %s" % unit.unit_id))
+        with self._state.lock:
+            # The unit has to exist.
+            existing_unit = None
+            for candidate in self._state.all_units:
+                if (
+                    candidate.content_type_id == unit.content_type_id
+                    and candidate.unit_id == unit.unit_id
+                ):
+                    existing_unit = candidate
+                    break
+            else:
+                return f_return_error(
+                    PulpException("unit not found: %s" % unit.unit_id)
+                )
 
-        # OK, we have a unit to update. Figure out which fields we can update.
-        update = {}
-        for fld in unit._usermeta_fields():
-            update[fld.name] = getattr(unit, fld.name)
+            # OK, we have a unit to update. Figure out which fields we can update.
+            update = {}
+            for fld in unit._usermeta_fields():
+                update[fld.name] = getattr(unit, fld.name)
 
-        updated_unit = attr.evolve(existing_unit, **update)
+            updated_unit = attr.evolve(existing_unit, **update)
 
-        unit_key = units.make_unit_key(updated_unit)
-        self._units_by_key[unit_key] = updated_unit
+            unit_key = units.make_unit_key(updated_unit)
+            self._state.units_by_key[unit_key] = updated_unit
 
         return f_return()
 
     def update_repository(self, repository):
         self._ensure_alive()
 
-        existing_repo = None
-        for candidate in self._repositories:
-            if candidate.id == repository.id:
-                existing_repo = candidate
-                break
-        else:
-            return f_return_error(
-                PulpException("repository not found: %s" % repository.id)
-            )
+        with self._state.lock:
+            existing_repo = None
+            for candidate in self._state.repositories:
+                if candidate.id == repository.id:
+                    existing_repo = candidate
+                    break
+            else:
+                return f_return_error(
+                    PulpException("repository not found: %s" % repository.id)
+                )
 
-        # We've got a repo, now update it.
-        update = {}
-        for fld in existing_repo._mutable_note_fields():
-            update[fld.name] = getattr(repository, fld.name)
+            # We've got a repo, now update it.
+            update = {}
+            for fld in existing_repo._mutable_note_fields():
+                update[fld.name] = getattr(repository, fld.name)
 
-        updated_repo = attr.evolve(existing_repo, **update)
+            updated_repo = attr.evolve(existing_repo, **update)
 
-        self._repositories = [
-            repo for repo in self._repositories if repo.id != updated_repo.id
-        ] + [updated_repo]
+            self._state.repositories = [
+                repo for repo in self._state.repositories if repo.id != updated_repo.id
+            ] + [updated_repo]
 
         return f_return()
 
@@ -372,7 +249,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         search_for_criteria(criteria, Distributor)
 
         try:
-            for repo in self._repositories:
+            for repo in self._state.repositories[:]:
                 for distributor in repo.distributors:
                     if match_object(criteria, distributor):
                         distributors.append(attr.evolve(distributor, repo_id=repo.id))
@@ -390,7 +267,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         search_for_criteria(criteria)
 
         try:
-            for task in self._tasks:
+            for task in self._state.tasks[:]:
                 if match_object(criteria, task):
                     tasks.append(task)
         except Exception as ex:  # pylint: disable=broad-except
@@ -411,7 +288,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         if repo_f.exception():
             return repo_f
 
-        repo_units = self._repo_units(repo_id)
+        with self._state.lock:
+            repo_units = self._state.repo_units(repo_id)
+
         out = []
 
         try:
@@ -461,10 +340,13 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
     def get_maintenance_report(self):
         self._ensure_alive()
 
-        if self._maintenance_report:
-            report = MaintenanceReport._from_data(json.loads(self._maintenance_report))
-        else:
-            report = MaintenanceReport()
+        with self._state.lock:
+            if self._state.maintenance_report:
+                report = MaintenanceReport._from_data(
+                    json.loads(self._state.maintenance_report)
+                )
+            else:
+                report = MaintenanceReport()
         return f_proxy(f_return(report))
 
     def set_maintenance(self, report):
@@ -479,21 +361,23 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         upload_ft = repo.upload_file(report_fileobj, "repos.json")
 
         publish_ft = f_flat_map(upload_ft, lambda _: repo.publish())
-        self._maintenance_report = report_json
+        self._state.maintenance_report = report_json
 
         return f_proxy(publish_ft)
 
     def get_content_type_ids(self):
         self._ensure_alive()
 
-        return f_proxy(f_return(self._type_ids))
+        return f_proxy(f_return(self._state.type_ids))
 
     def _do_upload_file(
         self, upload_id, file_obj, name="<unknown file>"
     ):  # pylint: disable=unused-argument
         # We keep track of uploaded content as we may need it at import time.
         buffer = six.BytesIO()
-        self._uploads_pending[upload_id] = buffer
+
+        with self._state.lock:
+            self._state.uploads_pending[upload_id] = buffer
 
         is_file_obj = "close" in dir(file_obj)
         if not is_file_obj:
@@ -523,46 +407,55 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         if repo_f.exception():
             return repo_f
 
-        current = self._repo_unit_keys.get(repo_id, set())
-        units_with_key = [
-            {"key": key, "unit": self._units_by_key[key]} for key in current
-        ]
-        removed_units = set()
-        kept_keys = set()
+        with self._state.lock:
+            current = self._state.repo_unit_keys.get(repo_id, set())
+            units_with_key = [
+                {"key": key, "unit": self._state.units_by_key[key]} for key in current
+            ]
+            removed_units = set()
+            kept_keys = set()
 
-        criteria = criteria or Criteria.true()
-        # validating the criteria here like in actual scenario.
-        pulp_search = search_for_criteria(criteria, type_hint=Unit, type_ids_accum=None)
-
-        # raise an error if criteria with filters doesn't include type_ids
-        if pulp_search.filters and not pulp_search.type_ids:
-            raise ValueError(
-                "Criteria to remove_content must specify at least one unit type!"
+            criteria = criteria or Criteria.true()
+            # validating the criteria here like in actual scenario.
+            pulp_search = search_for_criteria(
+                criteria, type_hint=Unit, type_ids_accum=None
             )
 
-        for unit_with_key in units_with_key:
-            unit = unit_with_key["unit"]
-            if match_object(criteria, unit):
-                removed_units.add(unit)
-            else:
-                kept_keys.add(unit_with_key["key"])
+            # raise an error if criteria with filters doesn't include type_ids
+            if pulp_search.filters and not pulp_search.type_ids:
+                raise ValueError(
+                    "Criteria to remove_content must specify at least one unit type!"
+                )
 
-        self._repo_unit_keys[repo_id] = kept_keys
+            for unit_with_key in units_with_key:
+                unit = unit_with_key["unit"]
+                if match_object(criteria, unit):
+                    removed_units.add(unit)
+                else:
+                    kept_keys.add(unit_with_key["key"])
 
-        task = Task(
-            id=self._next_task_id(),
-            repo_id=repo_id,
-            completed=True,
-            succeeded=True,
-            units=units.with_key_only(removed_units),
-        )
+            self._state.repo_unit_keys[repo_id] = kept_keys
+
+            task = Task(
+                id=self._state.next_task_id(),
+                repo_id=repo_id,
+                completed=True,
+                succeeded=True,
+                units=units.with_key_only(removed_units),
+            )
 
         return f_return([task])
 
     def _request_upload(self, name):  # pylint: disable=unused-argument
+        # Note: old versions had a bug where this function would always
+        # consume *two* request IDs. We keep that side-effect so that test
+        # data produced with that bug remains stable.
+        self._state.next_request_id()
+
+        upload_id = self._state.next_request_id()
         upload_request = {
-            "_href": "/pulp/api/v2/content/uploads/%s/" % self._next_request_id(),
-            "upload_id": "%s" % self._next_request_id(),
+            "_href": "/pulp/api/v2/content/uploads/%s/" % upload_id,
+            "upload_id": "%s" % upload_id,
         }
 
         return f_return(upload_request)
@@ -577,28 +470,29 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         repo = repo_f.result()
 
-        # Get the uploaded content we're about to import; though it's not
-        # guaranteed to be present (e.g. erratum has no file).
-        # If not present, we just use an empty BytesIO.
-        upload_content = self._uploads_pending.pop(upload_id, six.BytesIO())
-        upload_content.seek(0)
+        with self._state.lock:
+            # Get the uploaded content we're about to import; though it's not
+            # guaranteed to be present (e.g. erratum has no file).
+            # If not present, we just use an empty BytesIO.
+            upload_content = self._state.uploads_pending.pop(upload_id, six.BytesIO())
+            upload_content.seek(0)
 
-        new_units = self._unitmaker.make_units(
-            unit_type_id, unit_key, unit_metadata, upload_content, repo_id
-        )
-        new_units = [
-            attr.evolve(u, repository_memberships=[repo.id]) for u in new_units
-        ]
-
-        self._insert_repo_units(repo_id, new_units)
-
-        task = Task(id=self._next_task_id(), completed=True, succeeded=True)
-
-        # upload_history is a deprecated field, data is maintained for iso only.
-        if unit_type_id == "iso":
-            self._upload_history.append(
-                Upload(repo, [task], unit_key["name"], unit_key["checksum"])
+            new_units = self._state.unitmaker.make_units(
+                unit_type_id, unit_key, unit_metadata, upload_content, repo_id
             )
+            new_units = [
+                attr.evolve(u, repository_memberships=[repo.id]) for u in new_units
+            ]
+
+            self._state.insert_repo_units(repo_id, new_units)
+
+            task = Task(id=self._state.next_task_id(), completed=True, succeeded=True)
+
+            # upload_history is a deprecated field, data is maintained for iso only.
+            if unit_type_id == "iso":
+                self._state.upload_history.append(
+                    Upload(repo, [task], unit_key["name"], unit_key["checksum"])
+                )
 
         return f_return([task])
 
@@ -616,9 +510,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         )  # pragma: no cover
 
     def _delete_repository(self, repo_id):
-        with self._lock:
+        with self._state.lock:
             found = False
-            for idx, repo in enumerate(self._repositories):
+            for idx, repo in enumerate(self._state.repositories):
                 if repo.id == repo_id:
                     found = True
                     break
@@ -627,14 +521,14 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
                 # Deleting something which already doesn't exist is fine
                 return f_return([])
 
-            self._repositories.pop(idx)  # pylint: disable=undefined-loop-variable
-            self._repo_unit_keys.pop(repo_id, None)
+            self._state.repositories.pop(idx)  # pylint: disable=undefined-loop-variable
+            self._state.repo_unit_keys.pop(repo_id, None)
             return f_return(
-                [Task(id=self._next_task_id(), completed=True, succeeded=True)]
+                [Task(id=self._state.next_task_id(), completed=True, succeeded=True)]
             )
 
     def _delete_distributor(self, repo_id, distributor_id):
-        with self._lock:
+        with self._state.lock:
             repo_f = self.get_repository(repo_id)
             if repo_f.exception():
                 # Repo can't be found, let that exception propagate
@@ -650,13 +544,15 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
                 # Deleting something which already doesn't exist is fine
                 return f_return([])
 
-            idx = self._repositories.index(repo)
-            self._repositories[idx] = attr.evolve(repo, distributors=new_distributors)
+            idx = self._state.repositories.index(repo)
+            self._state.repositories[idx] = attr.evolve(
+                repo, distributors=new_distributors
+            )
 
             return f_return(
                 [
                     Task(
-                        id=self._next_task_id(),
+                        id=self._state.next_task_id(),
                         completed=True,
                         succeeded=True,
                         tags=[
@@ -674,11 +570,14 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             # Repo can't be found, let that exception propagate
             return repo_f
 
-        tasks = []
-        for _ in distributors_with_config:
-            tasks.append(Task(id=self._next_task_id(), completed=True, succeeded=True))
+        with self._state.lock:
+            tasks = []
+            for _ in distributors_with_config:
+                tasks.append(
+                    Task(id=self._state.next_task_id(), completed=True, succeeded=True)
+                )
 
-        self._publish_history.append(Publish(repo, tasks))
+            self._state.publish_history.append(Publish(repo, tasks))
 
         return f_return(tasks)
 
@@ -698,16 +597,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             # Repo can't be found, let that exception propagate
             return repo_f
 
-        task = Task(id=self._next_task_id(), completed=True, succeeded=True)
+        with self._state.lock:
+            task = Task(id=self._state.next_task_id(), completed=True, succeeded=True)
 
-        self._sync_history.append(Sync(repo_f.result(), [task], sync_config))
+            self._state.sync_history.append(Sync(repo_f.result(), [task], sync_config))
 
         return f_return([task])
-
-    def _next_task_id(self):
-        with self._lock:
-            next_raw_id = self._uuidgen.randint(0, 2**128)
-        return str(uuid.UUID(int=next_raw_id))
-
-    def _next_request_id(self):
-        return self._next_task_id()

--- a/pubtools/pulplib/_impl/fake/state.py
+++ b/pubtools/pulplib/_impl/fake/state.py
@@ -1,0 +1,163 @@
+import threading
+import random
+import uuid
+import attr
+
+
+from . import units
+
+from pubtools.pulplib import FileUnit
+
+
+class FakeState(object):
+    # Private class holding all state associated with fake clients.
+    #
+    # A single state object can be accessed by multiple clients.
+    # It can be thought of as similar to the (DB & filesystem) on a real
+    # Pulp installation.
+    #
+    # Clients modifying state must explicitly lock this object.
+    # Some read operations also require holding the lock.
+
+    _DEFAULT_TYPE_IDS = [
+        "distribution",
+        "drpm",
+        "erratum",
+        "iso",
+        "modulemd_defaults",
+        "modulemd",
+        "package_category",
+        "package_environment",
+        "package_group",
+        "package_langpacks",
+        "repository",
+        "rpm",
+        "srpm",
+        "yum_repo_metadata_file",
+    ]
+
+    def __init__(self):
+        self.repositories = []
+
+        # Similar to a real Pulp server, units are stored through a "unit key"
+        # layer of indirection:
+        # - repos contain unit keys
+        # - a unit key refers to one (and only one) unit
+        #
+        # By storing data in this way, we ensure we have similar behavior and
+        # constraints as a real Pulp server, e.g. cannot store two different units
+        # which would have the same key; updating a unit referenced from multiple repos
+        # effectively updates it in all repos at once; etc.
+        self.repo_unit_keys = {}
+        self.units_by_key = {}
+
+        self.publish_history = []
+        self.upload_history = []
+        self.uploads_pending = {}
+        self.sync_history = []
+        self.tasks = []
+        self.maintenance_report = None
+        self.type_ids = self._DEFAULT_TYPE_IDS[:]
+        self.seen_unit_ids = set()
+        self.lock = threading.Lock()
+        self.uuidgen = random.Random()
+        self.uuidgen.seed(0)
+        self.unitmaker = units.UnitMaker(self.seen_unit_ids)
+
+    def insert_repo_units(self, repo_id, units_to_add):
+        # Insert an iterable of units into a specific repo.
+        #
+        # If a unit with the same key exists in multiple repos, this will update
+        # matching units across *all* of those repos - same as a real pulp server.
+        assert self.lock.locked()
+
+        repo_unit_keys = self.repo_unit_keys.setdefault(repo_id, set())
+        memberships = []
+        if repo_id is not None:
+            memberships.append(repo_id)
+
+        for unit in units_to_add:
+            # Always consume a unit ID from the unitmaker even if we don't actually
+            # need it. The point of this is to ensure that if you serialize/deserialize
+            # a fake client, e.g. as done in pubtools-pulp, then the freshly created
+            # client will not try to use the same sequence of IDs as already used in
+            # the units we've just deserialized.
+            unit_id = self.unitmaker.next_unit_id()
+
+            if not unit.unit_id:
+                unit = attr.evolve(unit, unit_id=unit_id)
+
+            self.seen_unit_ids.add(unit.unit_id)
+
+            # Unit belongs to the repo we're adding it to.
+            # Note: this may be further merged with an existing unit's
+            # repository_memberships a few lines below.
+            unit = attr.evolve(
+                unit,
+                repository_memberships=(unit.repository_memberships or [])
+                + memberships,
+            )
+
+            if repo_id is not None:
+                # Unit might be replacing earlier units in same repo.
+                self.remove_clashing_units(repo_id, unit)
+
+            unit_key = units.make_unit_key(unit)
+            old_unit = self.units_by_key.get(unit_key)
+            self.units_by_key[unit_key] = units.merge_units(old_unit, unit)
+            repo_unit_keys.add(unit_key)
+
+    def remove_clashing_units(self, repo_id, unit):
+        assert self.lock.locked()
+
+        # In preparation for adding 'unit' into a repo, remove any existing
+        # units from that repo which would clash, in a compatible manner as Pulp.
+        #
+        # Currently this is a special case only for File units: although their
+        # unit_key consists of more than just 'name' making it technically possible
+        # to have multiple files with the same name in a repo, Pulp has special logic
+        # to try to prevent this, so we do the same here.
+        if isinstance(unit, FileUnit):
+            for existing in self.repo_units(repo_id):
+                if isinstance(existing, FileUnit) and existing.path == unit.path:
+                    self.remove_unit(repo_id, existing)
+
+    def remove_unit(self, repo_id, unit):
+        # Remove a single unit from a repository.
+        assert self.lock.locked()
+
+        unit_key = units.make_unit_key(unit)
+
+        # Ensure unit is no longer referenced from the repo
+        self.repo_unit_keys[repo_id].remove(unit_key)
+
+        # Ensure repo ID is no longer in memberships
+        new_repos = [id for id in unit.repository_memberships if id != repo_id]
+        self.units_by_key[unit_key] = attr.evolve(
+            unit, repository_memberships=new_repos
+        )
+
+    @property
+    def all_units(self):
+        # Get all units in all repos.
+        #
+        # Cannot be used to modify units.
+        return list(self.units_by_key.values())
+
+    def repo_units(self, repo_id):
+        # Get all units in a particular repo.
+        #
+        # Cannot be used to modify units.
+        assert self.lock.locked()
+
+        out = []
+        for key in self.repo_unit_keys.get(repo_id) or []:
+            out.append(self.units_by_key[key])
+        return out
+
+    def next_task_id(self):
+        next_raw_id = self.uuidgen.randint(0, 2**128)
+        return str(uuid.UUID(int=next_raw_id))
+
+    def next_request_id(self):
+        return self.next_task_id()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.31.0",
+    version="2.32.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake_shared_state.py
+++ b/tests/fake/test_fake_shared_state.py
@@ -1,0 +1,84 @@
+import pytest
+
+from pubtools.pulplib import (
+    FakeController,
+    RpmUnit,
+    YumRepository,
+    CopyOptions,
+)
+
+
+@pytest.fixture
+def controller():
+    return FakeController()
+
+
+def test_clients_share_state(controller):
+    """Multiple clients created by the same controller share state"""
+    src = YumRepository(id="src-repo")
+    dest = YumRepository(id="dest-repo")
+    controller.insert_repository(src)
+    controller.insert_repository(dest)
+
+    src_units = [
+        RpmUnit(name="bash", version="4.0", release="1", arch="x86_64"),
+        RpmUnit(name="bash", version="4.0", release="2", arch="x86_64"),
+        RpmUnit(name="bash", version="4.1", release="3", arch="x86_64"),
+        RpmUnit(name="glibc", version="5.0", release="1", arch="x86_64"),
+    ]
+    controller.insert_units(src, src_units)
+
+    client1 = controller.new_client()
+    client2 = controller.new_client()
+
+    # The two clients should not be the same object
+    assert client1 is not client2
+
+    # Repos are initially detached, re-fetch them via client
+    src = client1.get_repository(src.id).result()
+    dest = client1.get_repository(dest.id).result()
+
+    # Do a copy via client1
+    client1.copy_content(
+        src, dest, options=CopyOptions(require_signed_rpms=False)
+    ).result()
+
+    # Then search for content via client2
+    found_units = list(client2.search_content())
+
+    # It should be able to see the outcome of the copy done via client1;
+    # i.e. repository_memberships contains both repos after the copy
+    assert sorted(found_units, key=repr) == [
+        RpmUnit(
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+            repository_memberships=["src-repo", "dest-repo"],
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+        ),
+        RpmUnit(
+            name="bash",
+            version="4.0",
+            release="2",
+            arch="x86_64",
+            repository_memberships=["src-repo", "dest-repo"],
+            unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
+        ),
+        RpmUnit(
+            name="bash",
+            version="4.1",
+            release="3",
+            arch="x86_64",
+            repository_memberships=["src-repo", "dest-repo"],
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
+        ),
+        RpmUnit(
+            name="glibc",
+            version="5.0",
+            release="1",
+            arch="x86_64",
+            repository_memberships=["src-repo", "dest-repo"],
+            unit_id="23a7711a-8133-2876-37eb-dcd9e87a1613",
+        ),
+    ]


### PR DESCRIPTION
In RHELDST-11375 I have a case which requires the usage of multiple
client instances within a single task. Fake clients currently won't
support this properly, because the client embeds its own state so that
separate clients won't see each other's changes.

Refactor it to support multiple fakes attached to a single controller.
All the Pulp state is moved out into a separate (private) object which
can be accessed by any number of fakes.