### PR TITLE
Support limiting returned fields during search [RHELDST-11485]

### DIFF
--- a/docs/api/searching.rst
+++ b/docs/api/searching.rst
@@ -32,6 +32,9 @@ Class reference
 
 .. autoclass:: pubtools.pulplib.Criteria
    :members:
+   :exclude-members: with_unit_type
+
+   .. automethod:: with_unit_type(unit_type, unit_fields=None)
 
 .. autoclass:: pubtools.pulplib.Matcher
    :members:

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -116,6 +116,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             ):
                 continue
             if match_object(criteria, unit):
+                unit = units.with_filtered_fields(unit, prepared_search.unit_fields)
                 out.append(unit)
 
         # callers should not make any assumption about the order of returned
@@ -280,9 +281,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         criteria = criteria or Criteria.true()
 
         # Pass the criteria through the same handling as used by the real client
-        # for serialization, to ensure we reject criteria also rejected by real client.
-        # We don't actually use the result, this is only for validation.
-        search_for_criteria(criteria, Unit)
+        # for serialization, to ensure we reject criteria also rejected by real client
+        # and also accumulate unit_fields.
+        prepared_search = search_for_criteria(criteria, Unit)
 
         repo_f = self.get_repository(repo_id)
         if repo_f.exception():
@@ -296,6 +297,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
         try:
             for unit in repo_units:
                 if match_object(criteria, unit):
+                    unit = units.with_filtered_fields(unit, prepared_search.unit_fields)
                     out.append(unit)
         except Exception as ex:  # pylint: disable=broad-except
             return f_return_error(ex)
@@ -418,7 +420,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             criteria = criteria or Criteria.true()
             # validating the criteria here like in actual scenario.
             pulp_search = search_for_criteria(
-                criteria, type_hint=Unit, type_ids_accum=None
+                criteria, type_hint=Unit, unit_type_accum=None
             )
 
             # raise an error if criteria with filters doesn't include type_ids

--- a/pubtools/pulplib/_impl/fake/units.py
+++ b/pubtools/pulplib/_impl/fake/units.py
@@ -378,3 +378,27 @@ def with_key_only(units):
         out.append(klass(**kwargs))
 
     return out
+
+
+def with_filtered_fields(unit, fields):
+    # Given a unit and a set of fields (e.g. from a prepared search),
+    # returns a copy of that unit with only the specified fields (plus
+    # a few special cases), similarly to a Pulp server's handling of the
+    # 'fields' argument during a search.
+    if fields is None:
+        return unit
+
+    model_field_names = set([f.model_field_name for f in fields])
+
+    # These are special, not subject to field filtering.
+    model_field_names.add("repository_memberships")
+    model_field_names.add("unit_id")
+    model_field_names.add("content_type_id")
+
+    klass = type(unit)
+    kwargs = {}
+    for field in attr.fields(klass):
+        if field.name in model_field_names:
+            kwargs[field.name] = getattr(unit, field.name)
+
+    return klass(**kwargs)

--- a/pubtools/pulplib/_impl/schema/unit.yaml
+++ b/pubtools/pulplib/_impl/schema/unit.yaml
@@ -129,7 +129,6 @@ definitions:
     required:
     - _content_type_id
     - name
-    - epoch
     - version
     - release
     - arch

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.32.0",
+    version="2.33.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -121,6 +121,44 @@ def test_search_content_by_type(populated_repo):
     ]
 
 
+def test_search_content_with_fields(populated_repo):
+    """search_content can limit fields"""
+
+    # unit_fields=[] will request the minimum possible set of fields.
+    crit = Criteria.with_unit_type(RpmUnit, unit_fields=[])
+
+    units = list(populated_repo.search_content(crit))
+    assert sorted(units) == [
+        # Note that 'sourcerpm' and 'provides' fields, visible in other tests,
+        # are filtered out here.
+        RpmUnit(
+            unit_id="82e2e662-f728-b4fa-4248-5e3a0a5d2f34",
+            content_type_id="srpm",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="src",
+            repository_memberships=["repo1"],
+        ),
+        RpmUnit(
+            unit_id="e3e70682-c209-4cac-629f-6fbed82c07cd",
+            name="bash",
+            version="4.0",
+            release="1",
+            arch="x86_64",
+            repository_memberships=["repo1"],
+        ),
+        RpmUnit(
+            unit_id="d4713d60-c8a7-0639-eb11-67b367a9c378",
+            name="glibc",
+            version="5.0",
+            release="1",
+            arch="x86_64",
+            repository_memberships=["repo1"],
+        ),
+    ]
+
+
 def test_search_erratum_by_type(populated_repo):
     """search_content for erratum returns matching content"""
 


### PR DESCRIPTION
The Pulp API supports returning a subset of fields during search, but
pulplib API didn't support this. Add it now. When constructing a
Criteria for a particular unit type, it is possible to specify the
desired fields associated with that type.

This was previously not added in the interest of keeping the API
simpler, but according to continued analysis of pubtools-pulp-push
performance it may be needed to reduce the memory usage.

That command currently discards many unnecessary fields immediately
after search, but that approach still consumes a lot of memory over
time. This is likely due to heap fragmentation as we keep allocating
and discarding memory for the unused fields. It is better to never
construct objects for the unneeded fields in the first place.