### PR TITLE
Fix flaky search on 'version' field [RHELDST-12664]

### DIFF
--- a/pubtools/pulplib/_impl/client/errors.py
+++ b/pubtools/pulplib/_impl/client/errors.py
@@ -19,3 +19,8 @@ class TaskFailedException(PulpException):
 class MissingTaskException(PulpException):
     # this is not public API, this exception should be extremely rare
     pass
+
+
+class AmbiguousQueryException(PulpException):
+    # not public API
+    pass

--- a/pubtools/pulplib/_impl/model/unit/base.py
+++ b/pubtools/pulplib/_impl/model/unit/base.py
@@ -32,6 +32,13 @@ def type_ids_for_class(unit_class):
     return sorted(out)
 
 
+def class_for_type_id(type_id):
+    # Inverse of type_ids_for_class: given a Pulp type ID,
+    # returns the corresponding Unit class, or None if there is no
+    # corresponding class.
+    return UNIT_CLASSES.get(type_id)
+
+
 @attr.s(kw_only=True, frozen=True)
 class Unit(PulpObject):
     """Represents a Pulp unit (a single piece of content).

--- a/tests/client/test_search_ambiguity.py
+++ b/tests/client/test_search_ambiguity.py
@@ -1,0 +1,44 @@
+import pytest
+import textwrap
+
+from pubtools.pulplib import Criteria, Unit, FileUnit
+
+from pubtools.pulplib._impl.client.search import (
+    filters_for_criteria,
+    field_match,
+)
+
+
+def test_error_on_ambiguous_field():
+    """A query with an ambiguous field reference can't be executed."""
+    crit = Criteria.with_field("version", "abc123")
+    message = textwrap.dedent(
+        """
+        Field 'version' is ambiguous.
+        A subtype of Unit must be provided to select one of the following groups:
+          ErratumUnit.version, ModulemdUnit.version, RpmUnit.version
+          FileUnit.version
+    """
+    ).strip()
+
+    # It should raise
+    with pytest.raises(Exception) as excinfo:
+        filters_for_criteria(crit, type_hint=Unit)
+
+    # It should tell us what the problem was
+    assert message in str(excinfo.value)
+
+
+def test_ambiguous_field_resolution():
+    """A field definition which would be ambiguous on Unit is disambiguated by giving
+    a specific Unit subclass in the criteria.
+    """
+
+    crit = Criteria.and_(
+        Criteria.with_unit_type(FileUnit), Criteria.with_field("version", "abc123")
+    )
+
+    # It should run OK and use the correct FileUnit storage for version field
+    assert filters_for_criteria(crit, type_hint=Unit) == {
+        "pulp_user_metadata.version": {"$eq": "abc123"}
+    }


### PR DESCRIPTION
FileUnit.version and ModulemdUnit.version are two fields both named
"version", but stored in Pulp in a different way, one of them being
top-level and the other stored under pulp_user_metadata.

Previously, the code responsible for generating the pulp search did not
take into account exactly what kind of unit is being searched for, and
it would end up picking one of the two Pulp fields essentially at
random. Fix it to first calculate which unit type is being queried and
then use that to resolve the ambiguity.

In cases where criteria remains ambiguous, an error is now raised on
search rather than picking one of the fields at random. It could
technically be considered a backwards-incompatible change, however any
clients currently using such a search might be getting incorrect results
at random without realizing it, so it seems best to introduce the check
even if it might break some existing code.