### PR TITLE
Expose include_in_download_service repo notes

### DIFF
--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -303,6 +303,34 @@ class Repository(PulpObject, Deletable):
     .. versionadded:: 2.29.0
     """
 
+    include_in_download_service = pulp_attrib(
+        default=False,
+        type=bool,
+        mutable=True,
+        pulp_field="notes.include_in_download_service",
+        pulp_py_converter=lambda x: x == "True",
+        py_pulp_converter=str,
+    )
+    """Flag indicating whether the repository is visible in production instance
+    of download service.
+
+    .. versionadded:: 2.34.0
+    """
+
+    include_in_download_service_preview = pulp_attrib(
+        default=False,
+        type=bool,
+        mutable=True,
+        pulp_field="notes.include_in_download_service_preview",
+        pulp_py_converter=lambda x: x == "True",
+        py_pulp_converter=str,
+    )
+    """Flag indicating whether the repository is visible in staging instance
+    of download service.
+
+    .. versionadded:: 2.34.0
+    """
+
     @distributors.validator
     def _check_repo_id(self, _, value):
         # checks if distributor's repository id is same as the repository it

--- a/pubtools/pulplib/_impl/schema/repository.yaml
+++ b/pubtools/pulplib/_impl/schema/repository.yaml
@@ -102,6 +102,20 @@ properties:
       ubi_config_version:
         type: string
 
+      # Flag indicating whether the repository is visible in production instance
+      # of download service. Stored as string.
+      include_in_download_service:
+        enum:
+          - "True"
+          - "False"
+
+      # Flag indicating whether the repository is visible in staging instance
+      # of download service. Stored as string.
+      include_in_download_service_preview:
+        enum:
+          - "True"
+          - "False"
+
   # List of repository distributors.
   # Note that order matters in this list.
   distributors:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.33.0",
+    version="2.34.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/client/test_update_repository.py
+++ b/tests/client/test_update_repository.py
@@ -33,8 +33,10 @@ def test_can_update_repo(requests_mocker, client):
     assert req.json() == {
         "delta": {
             "notes": {
+                "include_in_download_service": "False",
+                "include_in_download_service_preview": "False",
                 # Note the serialization into embedded JSON here.
-                "product_versions": '["1.0","1.1"]'
+                "product_versions": '["1.0","1.1"]',
             }
         }
     }

--- a/tests/repository/test_yum_repository.py
+++ b/tests/repository/test_yum_repository.py
@@ -67,6 +67,8 @@ def test_populate_attrs():
             "notes": {
                 "_repo-type": "rpm-repo",
                 "content_set": "fake_content_set",
+                "include_in_download_service": "True",
+                "include_in_download_service_preview": "True",
                 "population_sources": ["populate_repo1", "populate_repo2"],
                 "ubi_population": True,
                 "ubi_config_version": "fake_ubi_config_version",
@@ -78,6 +80,8 @@ def test_populate_attrs():
     assert repo.ubi_population
     assert repo.content_set == "fake_content_set"
     assert repo.ubi_config_version == "fake_ubi_config_version"
+    assert repo.include_in_download_service
+    assert repo.include_in_download_service_preview
 
 
 def test_productid_attrs():


### PR DESCRIPTION
Recently emerging utilities developed and used by release engineers
try to favor modern libraries such as pubtools-pulplib over the legacy
alternatives, however some functions existing in older libraries are
not provided by this library yet. The possibility to set or read
include_in_download_service[_preview] repo notes is one such feature
currently required, so this commit makes the repo notes accessible.