### PR TITLE
docs: fix compatibility with sphinx 5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -132,7 +132,7 @@ autodoc_member_order = "bysource"
 autodoc_inherit_docstrings = False
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "requests": ("https://2.python-requests.org/en/master/", None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
     "more-executors": ("https://rohanpm.github.io/more-executors/", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
 }


### PR DESCRIPTION
We don't pin the sphinx version when building docs, and recently
released sphinx 5 broke the build for a couple of reasons. Fix it:

- explicitly set a language, as None now triggers an error
- use up-to-date intersphinx URL for requests, as previous URL points at
  a server with an invalid cert (which was apparently accepted by
  earlier sphinx versions?)