### PR TITLE
Fixed converting cdn_published criteria search in RpmUnit and FileUnit 

### DIFF
--- a/pubtools/pulplib/_impl/model/convert.py
+++ b/pubtools/pulplib/_impl/model/convert.py
@@ -66,6 +66,17 @@ def tolerant_timestamp(value):
     return value
 
 
+def timestamp_converter(value):
+    # Converter for fields which are stored as strings,
+    # but which model is expecting datetime
+    # falls back to returning the input verbatim if not a datetime.
+    #
+    if isinstance(value, datetime.datetime):
+        return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return value
+
+
 def write_timestamp(value):
     # defaults to current time if value is None
     if value is None:

--- a/pubtools/pulplib/_impl/model/unit/file.py
+++ b/pubtools/pulplib/_impl/model/unit/file.py
@@ -4,7 +4,11 @@ from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
-from ..convert import frozenlist_or_none_sorted_converter, tolerant_timestamp
+from ..convert import (
+    frozenlist_or_none_sorted_converter,
+    tolerant_timestamp,
+    timestamp_converter,
+)
 from ..validate import optional_str, instance_of
 
 
@@ -125,6 +129,7 @@ class FileUnit(Unit):
         pulp_field="pulp_user_metadata.cdn_published",
         default=None,
         converter=tolerant_timestamp,
+        py_pulp_converter=timestamp_converter,
         validator=instance_of((datetime.datetime, type(None))),
     )
     """Approximate :class:`~datetime.datetime` in UTC at which this file first

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -9,6 +9,7 @@ from ..convert import (
     frozenlist_or_none_converter,
     frozenlist_or_none_sorted_converter,
     tolerant_timestamp,
+    timestamp_converter,
 )
 from ..validate import optional_str, instance_of
 from ..common import PulpObject
@@ -181,6 +182,7 @@ class RpmUnit(Unit):
         pulp_field="pulp_user_metadata.cdn_published",
         default=None,
         converter=tolerant_timestamp,
+        py_pulp_converter=timestamp_converter,
         validator=instance_of((datetime.datetime, type(None))),
     )
     """Approximate :class:`~datetime.datetime` in UTC at which this RPM first

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -8,6 +8,8 @@ from pubtools.pulplib._impl.client.search import (
     field_match,
 )
 
+from pubtools.pulplib import RpmUnit, FileUnit
+
 
 def test_null_criteria():
     """Searching for None or True translates to empty filters."""
@@ -99,4 +101,36 @@ def test_dict_matcher_value():
 
     assert filters_for_criteria(crit) == {
         "created": {"$lt": {"created_date": {"$date": "2019-09-04T00:00:00Z"}}}
+    }
+
+
+def test_cdn_published():
+    """criteria using cdn_published as matcher value
+    with a datetime in RpmUnit, FileUnit
+    """
+
+    crit = Criteria.with_field("cdn_published", datetime.datetime(2019, 9, 4, 0, 0, 0))
+
+    assert filters_for_criteria(crit, RpmUnit) == {
+        "pulp_user_metadata.cdn_published": {"$eq": "2019-09-04T00:00:00Z"}
+    }
+
+    assert filters_for_criteria(crit, FileUnit) == {
+        "pulp_user_metadata.cdn_published": {"$eq": "2019-09-04T00:00:00Z"}
+    }
+
+
+def test_cdn_published_not_datetime():
+    """criteria using cdn_published as matcher value
+    with a string in RpmUnit, FileUnit
+    """
+
+    crit = Criteria.with_field("cdn_published", "not datetime")
+
+    assert filters_for_criteria(crit, RpmUnit) == {
+        "pulp_user_metadata.cdn_published": {"$eq": "not datetime"}
+    }
+
+    assert filters_for_criteria(crit, FileUnit) == {
+        "pulp_user_metadata.cdn_published": {"$eq": "not datetime"}
     }


### PR DESCRIPTION
This will fix a bug when running a criteria search against cdn_published. Cdn_published is stored as a string but criteria is trying to use $date in the search.