### PR TITLE
Use time.monotonic on py3.3+

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   py27:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM

--- a/pubtools/pulplib/_impl/log.py
+++ b/pubtools/pulplib/_impl/log.py
@@ -1,6 +1,9 @@
 import logging
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 
 class TimedLogger(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ frozenlist2
 frozendict; python_version >= '3.6'
 pubtools>=0.3.0
 humanize
+monotonic; python_version < '3.3'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py36,static,pidiff,docs
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:py27]
 deps=


### PR DESCRIPTION
On Python 3.3 or newer, monotonic module aliases time.monotonic from the standard library. On older versions, it will fall back to an equivalent platform specific implementation provided by the monotonic module. This is reflected also in requirements.txt