### PR TITLE
Limit kw_only usage to attrs 18.2 or newer

### DIFF
--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -30,9 +30,11 @@ def s(*args, **kwargs):
         # don't use the attrs-generated repr by default
         kwargs["repr"] = False
 
-    if "kw_only" in kwargs and sys.version_info < (3,):  # pragma: no cover
-        # This is only implemented for Python 3.
-        # attrs will raise if kw_only is provided on Py2.
+    if "kw_only" in kwargs and (
+        ATTR_VERSION < (18, 2) or sys.version_info < (3,)
+    ):  # pragma: no cover
+        # This is only implemented for Python 3 and only in attrs 18.2 and newer.
+        # attrs will raise if kw_only is provided on Py2 or older version of attrs.
         del kwargs["kw_only"]
 
     return attr.s(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -37,17 +37,6 @@ usedevelop=true
 commands=
 	pytest -svv --timeout 60 --cov-report=html --cov-report=xml --cov=pubtools --cov-fail-under=100 {posargs}
 
-[testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
-deps=
-	-rtest-requirements.txt
-	pytest-cov
-	coveralls
-usedevelop=true
-commands=
-	pytest --cov=pubtools {posargs}
-	coveralls --service=github
-
 [testenv:docs]
 deps=
 	sphinx


### PR DESCRIPTION
Apart from python2, the kw_only keyword argument for `attr.s()` throws `TypeError: attrs() got an unexpected keyword argument 'kw_only'` also on python3 installations using version of attrs module older than 18.2. RHEL-8 ships attrs in version 17.4, hence the argument needs to be excluded there as well.