### PR TITLE
Repo Lock [RHELDST-14968]

### DIFF
--- a/examples/repo-lock
+++ b/examples/repo-lock
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+from pubtools.pulplib import Client, FakeController, FileRepository
+import logging
+from argparse import ArgumentParser
+from threading import Thread
+import os
+from time import sleep
+
+log = logging.getLogger("repo_lock")
+
+
+def set_maintenance(client, maintenance_on, msg):
+    lock_name = ["pulplib-lock-example"]
+    maintenance_repo = client.get_repository("redhat-maintenance")
+    with maintenance_repo.lock("update maintenance repo", duration=600):
+        log.info(msg)
+        log.info("Downloading maintenance report")
+        report = client.get_maintenance_report()
+        report = report.result()
+        log.info("Modifying maintenance report")
+        if maintenance_on:
+            report = report.add(
+                lock_name, owner="pulplib-examples",
+                message="lock demonstration"
+            )
+        else:
+            report = report.remove(lock_name)
+        client.set_maintenance(report).result()
+
+
+def make_client(args):
+    auth = None
+    if args.fake:
+        ctrl = FakeController()
+        ctrl.insert_repository(FileRepository(id="redhat-maintenance"))
+        return ctrl.client
+    if args.username:
+        password = args.password
+        if password is None:
+            password = os.environ.get("PULP_PASSWORD")
+        if not password:
+            log.warning("No password provided for %s", args.username)
+        auth = (args.username, args.password)
+
+    return Client(args.url, auth=auth, verify=not args.insecure)
+
+
+def get_args():
+    parser = ArgumentParser(description="Demonstration of Repo Locking")
+    parser.add_argument("--url", help="Pulp server URL")
+    parser.add_argument("--username", help="Pulp username")
+    parser.add_argument(
+        "--password", help="Pulp password (or set PULP_PASSWORD in env)"
+    )
+    parser.add_argument("--insecure", default=False, action="store_true")
+    parser.add_argument("--fake", default=False, action="store_true")
+
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+    args = get_args()
+    client = make_client(args)
+    add_thread = Thread(
+        target=set_maintenance,
+        args=(client, True, "Adding to redhat-maintenance")
+    )
+    remove_thread = Thread(
+        target=set_maintenance,
+        args=(client, False, "Removing from redhat-maintenance")
+    )
+
+    add_thread.start()
+    sleep(1)
+    remove_thread.start()
+
+    add_thread.join()
+    remove_thread.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/pubtools/pulplib/_impl/fake/controller.py
+++ b/pubtools/pulplib/_impl/fake/controller.py
@@ -204,3 +204,11 @@ class FakeController(object):
         """
         with self._state.lock:
             self._state.tasks.append(task)
+
+    @property
+    def repo_lock_history(self):
+        """
+        A list containing all lock actions carried out.
+        Possible actions are: lock, unlock, multi-unlock
+        """
+        return self._state.repo_lock_history

--- a/pubtools/pulplib/_impl/fake/state.py
+++ b/pubtools/pulplib/_impl/fake/state.py
@@ -63,6 +63,10 @@ class FakeState(object):
         self.uuidgen = random.Random()
         self.uuidgen.seed(0)
         self.unitmaker = units.UnitMaker(self.seen_unit_ids)
+        # map of repo id => lock claims.
+        self.repo_locks = {}
+        # list containing lists of the lock state changes
+        self.repo_lock_history = []
 
     def insert_repo_units(self, repo_id, units_to_add):
         # Insert an iterable of units into a specific repo.

--- a/pubtools/pulplib/_impl/model/repository/repo_lock.py
+++ b/pubtools/pulplib/_impl/model/repository/repo_lock.py
@@ -1,0 +1,221 @@
+import json
+import random
+import string
+from time import sleep
+import os
+import logging
+
+from datetime import datetime, timedelta
+from more_executors.futures import f_map
+from requests.exceptions import HTTPError
+
+LOCK_CLAIM_STR = "pulplib-lock-claim-"
+
+LOCK_VALID_FROM_OFFSET = int(os.getenv("PULPLIB_LOCK_VALID_FROM_OFFSET", "10"))
+LOCK_EXPIRATION_OFFSET = int(os.getenv("PULPLIB_LOCK_EXPIRATION_OFFSET", "1800"))
+LOCK_EXPIRATION_OFFSET_MIN = int(os.getenv("PULPLIB_LOCK_EXPIRATION_OFFSET_MIN", "300"))
+LOCK_EXPIRATION_OFFSET_MAX = int(
+    os.getenv("PULPLIB_LOCK_EXPIRATION_OFFSET_MAX", "216000")
+)
+
+AWAIT_ACTIVATION_SLEEP = int(os.getenv("PULPLIB_AWAIT_ACTIVATION_SLEEP", " 10"))
+
+LOG = logging.getLogger("pubtools.pulplib")
+
+
+# datetime is a built-in so cannot be mocked directly.
+# This function is a workaround to allow mocking for testing.
+def now():
+    return datetime.now()  # pragma: no cover
+
+
+class LockClaim(object):
+    def __init__(self, **kwargs):
+        expiration_offset = kwargs.get("expiration_offset")
+        expiration_offset = (
+            expiration_offset if expiration_offset else LOCK_EXPIRATION_OFFSET
+        )
+        expiration_offset = max(
+            min(expiration_offset, LOCK_EXPIRATION_OFFSET_MAX),
+            LOCK_EXPIRATION_OFFSET_MIN,
+        )
+        self.id = (
+            kwargs["id"]
+            if "id" in kwargs
+            else "".join(random.choices(string.ascii_letters + string.digits, k=8))
+        )
+        self.context = kwargs["context"]
+        self.created = (
+            datetime.fromtimestamp(kwargs["created"]) if "created" in kwargs else now()
+        )
+        self.valid_from = (
+            datetime.fromtimestamp(kwargs["valid_from"])
+            if "valid_from" in kwargs
+            else self.created + timedelta(seconds=LOCK_VALID_FROM_OFFSET)
+        )
+        self.expires = (
+            datetime.fromtimestamp(kwargs["expires"])
+            if "expires" in kwargs
+            else self.created + timedelta(seconds=expiration_offset)
+        )
+
+    @property
+    def as_json(self):
+        data = {
+            "id": self.id,
+            "context": self.context,
+            "created": datetime.timestamp(self.created),
+            "valid_from": datetime.timestamp(self.valid_from),
+            "expires": datetime.timestamp(self.expires),
+        }
+        return json.dumps(data)
+
+    def __lt__(self, other):
+        return self.created < other.created
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    @staticmethod
+    def from_json_data(json_data):
+        return LockClaim(**json_data)
+
+    @property
+    def is_valid(self):
+        return self.valid_from < now() < self.expires
+
+    @property
+    def is_expired(self):
+        return now() > self.expires
+
+
+class RepoLock(object):
+    def __init__(
+        self,
+        repo_id,
+        client,
+        lock_context,
+        expiration_offset,
+    ):
+        self._repo_id = repo_id
+        self._client = client
+        self._lock_claim = None
+        self._lock_context = lock_context
+        self._expiration_offset = expiration_offset
+
+    def __enter__(self):
+        LOG.info("Attempting to lock %s.", self._repo_id)
+        self.remove_expired_locks()
+        self._lock_claim = LockClaim(
+            context=self._lock_context, expiration_offset=self._expiration_offset
+        )
+        self.submit_lock_claim()
+        self.await_lock_activation()
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if self._lock_claim.is_expired:
+            logging.error(
+                "Client requested lock on repo %s for %s seconds "
+                "but was held for %s seconds (%s)",
+                self._repo_id,
+                (self._lock_claim.expires - self._lock_claim.created).seconds,
+                (now() - self._lock_claim.created).seconds,
+                self._lock_claim.context,
+            )
+        self.delete_lock_claim()
+        self._lock_claim = None
+
+    def get_repo_lock_data(self, filter_invalid=False):
+        LOG.debug("Getting current repo lock data for %s.", self._repo_id)
+        locks_f = self._client._get_repo_lock_data(self._repo_id)
+        locks_f = f_map(
+            locks_f,
+            lambda locks: [
+                LockClaim.from_json_data(json.loads(l)) for l in locks.values()
+            ],
+        )
+        parsed_locks = locks_f.result()
+        parsed_locks.sort()
+        if filter_invalid:
+            parsed_locks = [l for l in parsed_locks if l.is_valid]
+        return parsed_locks
+
+    def await_lock_activation(self):
+        # if `now` is later than `valid_from`, the timedelta is negative and
+        # the seconds value becomes a whole day minus the timedelta ~ 86400.
+        # total_seconds returns a negative time value, which we clamp.
+        sleep(max((self._lock_claim.valid_from - now()).total_seconds(), 0))
+        while True:
+            lock_claims = self.get_repo_lock_data(filter_invalid=True)
+            # If our claim is the oldest valid lock claim.
+            if self._lock_claim == lock_claims[0]:
+                LOG.info("Lock obtained for %s.", self._repo_id)
+                return
+            LOG.info("Awaiting lock for %s.", self._repo_id)
+            sleep(AWAIT_ACTIVATION_SLEEP)
+
+    def submit_lock_claim(self):
+        LOG.info(
+            "Submitting lock with id '%s' to %s (%s).",
+            self._lock_claim.id,
+            self._repo_id,
+            self._lock_claim.context,
+        )
+        self._client._update_repo_lock_data(
+            self._repo_id,
+            {LOCK_CLAIM_STR + self._lock_claim.id: self._lock_claim.as_json},
+        )
+
+    def delete_lock_claim(self):
+        LOG.info(
+            "Deleting lock with id '%s' from %s (%s).",
+            self._lock_claim.id,
+            self._repo_id,
+            self._lock_claim.context,
+        )
+        note_delta = {LOCK_CLAIM_STR + self._lock_claim.id: None}
+        try:
+            self._client._update_repo_lock_data(
+                self._repo_id, note_delta, await_result=True
+            )
+        except HTTPError as e:
+            if self._pulp_exception_from_missing_lock(e, list(note_delta.keys())):
+                logging.error("Lock %s has already been deleted.", self._lock_claim.id)
+            else:
+                raise e  # pragma: no cover
+
+    def _pulp_exception_from_missing_lock(self, e, lock_names):
+        # If we try to delete a lock from pulp notes that's already been
+        # deleted, it will result in a 500 error due to a KeyError exception
+        # If multiple locks are sent for deletion, it appears Pulp will fail on
+        # the first missing one and not carry out any deletions.
+        lock_names = ["KeyError: '%s'\n" % lock for lock in lock_names]
+        return any(
+            [exception in lock_names for exception in e.response.json()["exception"]]
+        )
+
+    def remove_expired_locks(self):
+        expired_locks = [lock for lock in self.get_repo_lock_data() if lock.is_expired]
+        if expired_locks:
+            for lock in expired_locks:
+                LOG.warning(
+                    "Removing expired lock with id %s from %s (%s).",
+                    lock.id,
+                    self._repo_id,
+                    lock.context,
+                )
+            invalid_locks_delta = {
+                LOCK_CLAIM_STR + lock.id: None for lock in expired_locks
+            }
+            try:
+                self._client._update_repo_lock_data(self._repo_id, invalid_locks_delta)
+            except HTTPError as e:
+                if self._pulp_exception_from_missing_lock(
+                    e, list(invalid_locks_delta.keys())
+                ):
+                    logging.error(
+                        "An error occurred while trying to delete an expired "
+                        "lock. The locks have already been deleted"
+                    )
+                else:
+                    raise e  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.35.0",
+    version="2.36.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -108,3 +108,23 @@ def test_can_insert_orphans():
         attr.evolve(u, unit_id=None, repository_memberships=None) for u in found
     ]
     assert sorted(found_cmp, key=repr) == units
+
+
+def test_get_repo_lock_data_missing():
+    controller = FakeController()
+
+    repo_f = controller.client._get_repo_lock_data("not-a-repo")
+    with pytest.raises(PulpException) as raised:
+        repo_f.result()
+
+    assert "Repository id=not-a-repo not found" in str(raised.value)
+
+
+def test_update_repo_lock_data_missing():
+    controller = FakeController()
+
+    repo_f = controller.client._update_repo_lock_data("not-a-repo", {})
+    with pytest.raises(PulpException) as raised:
+        repo_f.result()
+
+    assert "Repository id=not-a-repo not found" in str(raised.value)

--- a/tests/repository/test_repo_lock.py
+++ b/tests/repository/test_repo_lock.py
@@ -1,0 +1,293 @@
+from datetime import datetime
+import logging
+
+import pytest
+from more_executors.futures import f_return
+from mock import patch, Mock, call
+from requests.exceptions import HTTPError
+
+from pubtools.pulplib._impl.model.repository.repo_lock import RepoLock, LockClaim
+from pubtools.pulplib import Client, FakeController, Repository
+
+
+@pytest.fixture
+def mock_client():
+    client = Client("https://pulp.example.com/")
+    client._request_executor.submit = Mock()
+    client._do_request = "do_request_func"
+    return client
+
+
+def pulp_get_response(key_values):
+    return f_return({"notes": key_values})
+
+
+def pulp_put_response():
+    return f_return({})
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.random")
+def test_repo_lock(random_mock, datetime_mock, mock_client):
+    datetime_mock.side_effect = [
+        datetime.fromtimestamp(1000.0),
+        datetime.fromtimestamp(1060.0),
+        datetime.fromtimestamp(1120.0),
+        datetime.fromtimestamp(1120.0),
+        datetime.fromtimestamp(1120.0),
+        datetime.fromtimestamp(1180.0),
+    ]
+    random_mock.choices = Mock(return_value="1234")
+    # Pulp API Calls
+    # 1. Get the current locks to check if three's stale ones. None this time.
+    # 2. Put our lock in the repo notes.
+    # 3. Get the current locks to check if it's our turn to run. (not yet)
+    # 3. Get the current locks again, it's our turn this time.
+    # 4. Delete the lock from the repo notes.
+    mock_client._request_executor.submit.side_effect = [
+        pulp_get_response({}),  # 1
+        pulp_put_response(),  # 2
+        pulp_get_response(
+            {
+                "pulplib-lock-claim-1233": '{"id": "1233", "context": "testing repo lock", "created": 900.0, "valid_from": 910.0, "expires": 1900.0}',
+                "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}',
+            }
+        ),  # 3
+        pulp_get_response(
+            {
+                "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}'
+            }
+        ),  # 4
+        pulp_put_response(),  # 5
+    ]
+    expected_endpoint = "https://pulp.example.com/pulp/api/v2/repositories/test-repo/"
+    expected_mock_calls = [
+        call("do_request_func", url=expected_endpoint, method="GET"),
+        call(
+            "do_request_func",
+            url=expected_endpoint,
+            method="PUT",
+            json={
+                "delta": {
+                    "notes": {
+                        "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}'
+                    }
+                }
+            },
+        ),
+        call("do_request_func", url=expected_endpoint, method="GET"),
+        call("do_request_func", url=expected_endpoint, method="GET"),
+        call(
+            "do_request_func",
+            url=expected_endpoint,
+            method="PUT",
+            json={"delta": {"notes": {"pulplib-lock-claim-1234": None}}},
+        ),
+    ]
+    lock = RepoLock(
+        "test-repo",
+        mock_client,
+        "testing repo lock",
+        1000,
+    )
+
+    # Runs __enter__ and __exit__ in RepoLock
+    with lock:
+        pass
+
+    mock_client._request_executor.submit.assert_has_calls(expected_mock_calls)
+    assert mock_client._request_executor.submit.call_count == 5
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.random")
+def test_repo_lock_fake_client(random_mock, datetime_mock):
+    datetime_mock.side_effect = [
+        datetime.fromtimestamp(1000.0),
+        datetime.fromtimestamp(1060.0),
+        datetime.fromtimestamp(1120.0),
+        datetime.fromtimestamp(1180.0),
+    ]
+    random_mock.choices = Mock(return_value="1234")
+    ctrl = FakeController()
+    ctrl.insert_repository(Repository(id="test-repo"))
+    lock = ctrl.new_client().get_repository("test-repo").lock("test")
+
+    # Runs __enter__ and __exit__ in RepoLock
+    with lock:
+        pass
+
+    lock_history = ctrl.repo_lock_history
+    assert len(lock_history) == 2
+    assert lock_history[0].repository == "test-repo"
+    assert lock_history[0].action == "lock"
+    assert lock_history[1].repository == "test-repo"
+    assert lock_history[1].action == "unlock"
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+def test_remove_expired_locks(datetime_mock, mock_client):
+    datetime_mock.return_value = datetime.fromtimestamp(3000.0)
+
+    mock_client._request_executor.submit.side_effect = [
+        pulp_get_response(
+            {
+                "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}',
+                "pulplib-lock-claim-1235": '{"id": "1235", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}',
+            }
+        ),
+        pulp_put_response(),
+    ]
+    expected_endpoint = "https://pulp.example.com/pulp/api/v2/repositories/test-repo/"
+    expected_mock_calls = [
+        call("do_request_func", url=expected_endpoint, method="GET"),
+        call(
+            "do_request_func",
+            url=expected_endpoint,
+            method="PUT",
+            json={
+                "delta": {
+                    "notes": {
+                        "pulplib-lock-claim-1234": None,
+                        "pulplib-lock-claim-1235": None,
+                    }
+                }
+            },
+        ),
+    ]
+    lock = RepoLock(
+        "test-repo",
+        mock_client,
+        "testing repo lock",
+        1000,
+    )
+
+    lock.remove_expired_locks()
+    mock_client._request_executor.submit.assert_has_calls(expected_mock_calls)
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+def test_remove_expired_locks_fake_client(datetime_mock):
+    datetime_mock.return_value = datetime.fromtimestamp(3000.0)
+    ctrl = FakeController()
+    ctrl.insert_repository(Repository(id="test-repo"))
+    client = ctrl.new_client()
+    client._update_repo_lock_data(
+        "test-repo",
+        {
+            "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}'
+        },
+    )
+    client._update_repo_lock_data(
+        "test-repo",
+        {
+            "pulplib-lock-claim-1235": '{"id": "1235", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}'
+        },
+    )
+
+    client.get_repository("test-repo").lock("test").remove_expired_locks()
+
+    lock_history = ctrl.repo_lock_history
+    assert len(lock_history) == 3
+    assert lock_history[0].repository == "test-repo"
+    assert lock_history[0].action == "lock"
+    assert lock_history[1].repository == "test-repo"
+    assert lock_history[1].action == "lock"
+    assert lock_history[2].repository == "test-repo"
+    assert lock_history[2].action == "multi-unlock"
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+def test_remove_expired_locks_error(datetime_mock, mock_client, caplog):
+    # We may cause an error if we try to delete a lock which has already been
+    # deleted. This may happen if another task runs clean up at the same time.
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "exception": ["KeyError: 'pulplib-lock-claim-1234'\n"]
+    }
+    mock_client._update_repo_lock_data = Mock(
+        side_effect=HTTPError(response=mock_response)
+    )
+    datetime_mock.return_value = datetime.fromtimestamp(3000.0)
+
+    mock_client._request_executor.submit.side_effect = [
+        pulp_get_response(
+            {
+                "pulplib-lock-claim-1234": '{"id": "1234", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}',
+                "pulplib-lock-claim-1235": '{"id": "1235", "context": "testing repo lock", "created": 1000.0, "valid_from": 1010.0, "expires": 2000.0}',
+            }
+        ),
+    ]
+
+    lock = RepoLock(
+        "test-repo",
+        mock_client,
+        "testing repo lock",
+        1000,
+    )
+
+    lock.remove_expired_locks()
+
+    assert (
+        "An error occurred while trying to delete an expired lock. The locks have already been deleted"
+        in caplog.messages
+    )
+
+
+def test_exception_handling_on_lock_delete(mock_client):
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "exception": ["KeyError: 'pulplib-lock-claim-1234'\n"]
+    }
+    mock_client._update_repo_lock_data = Mock(
+        side_effect=HTTPError(response=mock_response)
+    )
+    expected_mock_calls = [
+        call("test-repo", {"pulplib-lock-claim-1234": None}, await_result=True)
+    ]
+    lock = RepoLock(
+        "test-repo",
+        mock_client,
+        "testing repo lock",
+        1000,
+    )
+    lock._lock_claim = LockClaim.from_json_data(
+        {
+            "id": "1234",
+            "context": "test",
+            "created": 1000.0,
+            "valid_from": 1010.0,
+            "expires": 2000.0,
+        }
+    )
+
+    lock.delete_lock_claim()
+
+    mock_client._update_repo_lock_data.assert_has_calls(expected_mock_calls)
+
+
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.now")
+@patch("pubtools.pulplib._impl.model.repository.repo_lock.random")
+def test_repo_log_error_on_stale_lock(random_mock, datetime_mock, caplog):
+    # If we've held the lock for too long, there should be an error reported.
+    datetime_mock.side_effect = [
+        datetime.fromtimestamp(1000.0),
+        datetime.fromtimestamp(1060.0),
+        datetime.fromtimestamp(1120.0),
+        datetime.fromtimestamp(5000.0),
+        datetime.fromtimestamp(5000.0),
+    ]
+    random_mock.choices = Mock(return_value="1234")
+    ctrl = FakeController()
+    ctrl.insert_repository(Repository(id="test-repo"))
+    lock = ctrl.new_client().get_repository("test-repo").lock("test")
+
+    # Runs __enter__ and __exit__ in RepoLock
+    with lock:
+        pass
+
+    # Should have logged an error.
+    assert (
+        "Client requested lock on repo test-repo for 1800 seconds but was held for 4000 seconds (test)"
+        in caplog.messages
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,16 @@ usedevelop=true
 commands=
 	pytest -svv --timeout 60 --cov-report=html --cov-report=xml --cov=pubtools --cov-fail-under=100 {posargs}
 
+[testenv:lock]
+deps=
+	-rtest-requirements.txt
+	pytest-cov
+	pytest-timeout
+usedevelop=true
+commands=
+	pytest -svv ./tests/repository/test_repo_lock.py
+
+
 [testenv:docs]
 deps=
 	sphinx


### PR DESCRIPTION
Some pub tasks work on mutable pulp data, so if two such tasks are run at the same time one task may overwrite the results from the other. To address this, we can create a "lock" using the repository notes field. The task submits a note and waits for it to become valid, then starts executing the actual task if it's the oldest valid lock in the repository. 

First pass attempt at implementing what Rohan suggested. Looking for general comments on the overall approach. There's things like changing print statements to logs and adding tests that still need to be addressed.

I imagined this being used in a `with` statement. So the maintenance tasks become:

```
with self.pulp_client.get_repo_lock("redhat-maintenance"):
   report = self.get_maintenance_report().result()
   report = self.adjust_maintenance_report(report)
   self.set_maintenance(report).result()
```

