### PR TITLE
Do not include 'container_list' in Erratum model __repr__

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/erratum.py
+++ b/pubtools/pulplib/_impl/model/unit/erratum.py
@@ -392,6 +392,7 @@ class ErratumUnit(Unit):
         converter=freeze_or_empty,
         default=attr.Factory(frozenlist),
         validator=container_list_validator(),
+        repr=False,
     )
     """A list of container images associated with the advisory."""
 


### PR DESCRIPTION
When Erratum is copied from one repo to another, container_list is not populated by pulp (there's no reason for that), however attribute itself is set to be empty frozenlist, mechanism to repr only attributes which are different from default doesn't seem to work for frozenlist default. However there's no reason for container_list to be included in __repr__ output at all. 