### PR TITLE
Pin bandit version

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py3-bandit-exitzero
   bandit:
@@ -96,6 +96,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py3-bandit

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
-        run: sudo apt-get install -y rpm
+        run: sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
-        run: sudo apt-get install -y rpm
+        run: sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ mock
 kobo
 koji
 rpm-py-installer
+bandit==1.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands=
 
 [testenv:py3-bandit-exitzero]
 deps=
-    bandit
+    -rtest-requirements.txt
 commands=
     # Skip B101 low severity assert warnings in the tests directory
     bandit -r ./tests --severity-level low --exit-zero --skip B101
@@ -57,7 +57,7 @@ commands=
 
 [testenv:py3-bandit]
 deps=
-    bandit
+    -rtest-requirements.txt
 commands=
     bandit -r . -ll --exclude './.tox' --confidence-level medium
 


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.