### PR TITLE
Fix CI failure installing rpm-py-installer

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e static
   pidiff:
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e cov
 


### PR DESCRIPTION
This became broken by the release of pip 23.1 and virtualenv 20.21.1. Details on bug report:
junaruga/rpm-py-installer#276

Until there is a proper resolution, pin to an older virtualenv to avoid the issue.

Since the relevant deps here are used during installation of tox itself, the pinning unfortunately cannot be done using the requirements files consumed from within tox.