### PR TITLE
Use rpmdyn in CI rather than rpm-py-installer

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e static
   pidiff:
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e cov
 
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e py3-bandit-exitzero
   bandit:
@@ -96,6 +96,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e py3-bandit

--- a/pubtools/pulplib/_impl/fake/rpmlib.py
+++ b/pubtools/pulplib/_impl/fake/rpmlib.py
@@ -11,14 +11,13 @@ except Exception as ex:  # pragma: no cover, pylint: disable=broad-except
     #
     # Why: because there's no officially supported method of getting RPM bindings
     # in place by "pip install", making the dependency tricky on some environments.
-    # rpm-py-installer can often be used, so we provide that hint as we crash,
+    # rpmdyn can often be used, so we provide that hint as we crash,
     # but it's not appropriate to unconditionally depend on that.
     exception = ex
 
     def broken(*_args, **_kwargs):
         raise RuntimeError(
-            "kobo.rpmlib is not available\n"
-            + "Hint: consider 'pip install rpm-py-installer'"
+            "kobo.rpmlib is not available\nHint: consider 'pip install rpmdyn'"
         ) from exception
 
     get_rpm_header = broken

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ requests-mock
 mock
 kobo
 koji
-rpm-py-installer
+rpmdyn
 bandit==1.7.5


### PR DESCRIPTION
Due to junaruga/rpm-py-installer#276, it was necessary to pin a particular version of virtualenv.

Let's undo that pin and try an alternative provider of RPM bindings instead. This library works a different way which does not require downloading and compiling from RPM sources, and is compatible with the newest versions of pip and other tools.

This is somewhat experimental, so let's try it out here for a while first before rolling out anywhere else.