### PR TITLE
Don't overwrite headers passed to Client object

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -941,7 +941,11 @@ class Client(object):
     def _new_session(self):
         out = requests.Session()
         for key, value in self._session_kwargs.items():
-            setattr(out, key, value)
+            # Special case for headers update as requests module already populates some defaults
+            if key == "headers":
+                out.headers.update(value)
+            else:
+                setattr(out, key, value)
         return out
 
     def _do_request(self, **kwargs):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -41,6 +41,14 @@ def test_can_construct_with_session_args(requests_mocker):
     client = Client("https://pulp.example.com/", auth=("x", "y"), verify=False)
 
 
+def test_construct_updates_headers(requests_mocker):
+    """A client instance updates the default requests.Session headers."""
+    client = Client("https://pulp.example.com/", headers={"x": "y"})
+
+    # It should contain the passed header, but it should not be the only header
+    assert client._session.headers["x"] == "y" and len(client._session.headers) > 1
+
+
 def test_construct_raises_on_bad_args(requests_mocker):
     """A client instance cannot be constructed with unexpected args."""
     with pytest.raises(TypeError):


### PR DESCRIPTION
requests module populates Session object with several default headers. The behavior in pubtools-pulpib would cause the default headers dictionary to be completely overwritten by the one passed in kwargs. This is cumbersome in cases where a developer wants to set only a single header, e.g. `User-Agent`. The new behavior ensures the default values are retained and the new values passed in kwargs only update the existing headers dictionary.