### PR TITLE
Expose "provisioning" repo note

### DIFF
--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -332,6 +332,13 @@ class Repository(PulpObject, Deletable):
     .. versionadded:: 2.34.0
     """
 
+    provisioning = pulp_attrib(default=None, type=bool, pulp_field="notes.provisioning")
+    """Flag indicating whether the repository is currently in process of creation
+    and provisioning to other tools outside of Pulp.
+
+    .. versionadded:: 2.37.0
+    """
+
     @distributors.validator
     def _check_repo_id(self, _, value):
         # checks if distributor's repository id is same as the repository it

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.36.1",
+    version="2.37.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/repository/test_yum_repository.py
+++ b/tests/repository/test_yum_repository.py
@@ -70,18 +70,20 @@ def test_populate_attrs():
                 "include_in_download_service": "True",
                 "include_in_download_service_preview": "True",
                 "population_sources": ["populate_repo1", "populate_repo2"],
-                "ubi_population": True,
+                "provisioning": True,
                 "ubi_config_version": "fake_ubi_config_version",
+                "ubi_population": True,
             },
             "distributors": [],
         }
     )
-    assert repo.population_sources == ["populate_repo1", "populate_repo2"]
-    assert repo.ubi_population
     assert repo.content_set == "fake_content_set"
-    assert repo.ubi_config_version == "fake_ubi_config_version"
     assert repo.include_in_download_service
     assert repo.include_in_download_service_preview
+    assert repo.population_sources == ["populate_repo1", "populate_repo2"]
+    assert repo.provisioning
+    assert repo.ubi_config_version == "fake_ubi_config_version"
+    assert repo.ubi_population
 
 
 def test_productid_attrs():


### PR DESCRIPTION
Downstream release engineering utilities streamlining the repository management require this repo note in order to determine whether the repository has been fully created and finalized - i.e. provisioned to tools outside Pulp such as TPS.