### PR TITLE
Add more attrs backports [RHELDST-20261]

### DIFF
--- a/pubtools/pulplib/_impl/compat_attr.py
+++ b/pubtools/pulplib/_impl/compat_attr.py
@@ -49,10 +49,98 @@ else:
     fields_dict = attr.fields_dict
 
 
+validators = attr.validators
+
+if ATTR_VERSION < (19, 1):  # pragma: no cover
+    # Backport is_callable, deep_iterable and deep_mapping methods needed elsewhere
+    # for use with older attrs version
+    @s(repr=False, slots=False, hash=True)
+    class _IsCallableValidator:
+        def __call__(self, _inst, attr_, value):
+            if not callable(value):
+                message = (
+                    "'{name}' must be callable (got {value!r} that is a {actual!r})."
+                )
+                raise TypeError(
+                    msg=message.format(
+                        name=attr_.name, value=value, actual=value.__class__
+                    ),
+                    value=value,
+                )
+
+        def __repr__(self):
+            return "<is_callable validator>"
+
+    def is_callable():
+        return _IsCallableValidator()
+
+    @s(repr=False, slots=True, hash=True)
+    class _DeepIterable:
+        member_validator = attr.ib(validator=is_callable())
+        iterable_validator = attr.ib(
+            default=None, validator=validators.optional(is_callable())
+        )
+
+        def __call__(self, inst, attr_, value):
+            # pylint: disable=not-callable
+            if self.iterable_validator is not None:
+                self.iterable_validator(inst, attr_, value)
+
+            for member in value:
+                self.member_validator(inst, attr_, member)
+            # pylint: enable=not-callable
+
+        def __repr__(self):
+            iterable_identifier = (
+                ""
+                if self.iterable_validator is None
+                else f" {self.iterable_validator!r}"
+            )
+            return (
+                f"<deep_iterable validator for{iterable_identifier}"
+                f" iterables of {self.member_validator!r}>"
+            )
+
+    def deep_iterable(member_validator, iterable_validator=None):
+        if isinstance(member_validator, (list, tuple)):
+            member_validator = validators.and_(*member_validator)
+        return _DeepIterable(member_validator, iterable_validator)
+
+    @s(repr=False, slots=True, hash=True)
+    class _DeepMapping:
+        key_validator = attr.ib(validator=is_callable())
+        value_validator = attr.ib(validator=is_callable())
+        mapping_validator = attr.ib(
+            default=None, validator=validators.optional(is_callable())
+        )
+
+        def __call__(self, inst, attr_, value):
+            # pylint: disable=not-callable
+            if self.mapping_validator is not None:
+                self.mapping_validator(inst, attr_, value)
+
+            for key in value:
+                self.key_validator(inst, attr_, key)
+                self.value_validator(inst, attr_, value[key])
+            # pylint: enable=not-callable
+
+        def __repr__(self):
+            return (
+                f"<deep_mapping validator for objects mapping {self.key_validator!r} "
+                f"to {self.value_validator!r}>"
+            )
+
+    def deep_mapping(key_validator, value_validator, mapping_validator=None):
+        return _DeepMapping(key_validator, value_validator, mapping_validator)
+
+    validators.is_callable = is_callable
+    validators.deep_iterable = deep_iterable
+    validators.deep_mapping = deep_mapping
+
+
 ib = attr.ib
 Factory = attr.Factory
 fields = attr.fields
 evolve = attr.evolve
 has = attr.has
-validators = attr.validators
 NOTHING = attr.NOTHING


### PR DESCRIPTION
This commit backports `is_callable`, `deep_iterable` and `deep_mapping` methods. These backports are required for pubtools-pulplib to work on RHEL 8 using out-of-the-box versions of python3.6 and python modules, as RHEL 8 comes with ancient attrs 17.4.0