### PR TITLE
Add limit to unassociate [RHELDST-20725]

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -775,7 +775,7 @@ class Client(object):
             self._do_request, method="POST", url=url, json=body
         )
 
-    def _do_unassociate(self, repo_id, criteria=None):
+    def _do_unassociate(self, repo_id, criteria=None, limit=None):
         url = os.path.join(
             self._url, "pulp/api/v2/repositories/%s/actions/unassociate/" % repo_id
         )
@@ -799,6 +799,9 @@ class Client(object):
                 )
             else:
                 body["criteria"]["filters"] = {"unit": pulp_search.filters}
+
+        if limit:
+            body["criteria"]["limit"] = limit
 
         LOG.debug("Submitting %s unassociate: %s", url, body)
 

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -404,7 +404,7 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
         return out
 
-    def _do_unassociate(self, repo_id, criteria=None):
+    def _do_unassociate(self, repo_id, criteria=None, limit=None):
         repo_f = self.get_repository(repo_id)
         if repo_f.exception():
             return repo_f
@@ -431,7 +431,9 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
 
             for unit_with_key in units_with_key:
                 unit = unit_with_key["unit"]
-                if match_object(criteria, unit):
+                if match_object(criteria, unit) and (
+                    not limit or len(removed_units) < limit
+                ):
                     removed_units.add(unit)
                 else:
                     kept_keys.add(unit_with_key["key"])

--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -652,6 +652,10 @@ class Repository(PulpObject, Deletable):
                 be removed.
                 If criteria is omitted, all the content will be removed.
 
+            limit (None, int)
+                Limit the maximum number of units that will be disassociated by
+                pulp.
+
         Returns:
             Future[list[:class:`~pubtools.pulplib.Task`]]
                 A future which is resolved when content has been removed.
@@ -696,7 +700,13 @@ class Repository(PulpObject, Deletable):
                     Matcher.in_(type_ids),  # Criteria.with_field_in is deprecated
                 )
 
-        return f_proxy(self._client._do_unassociate(self.id, criteria=criteria))
+        return f_proxy(
+            self._client._do_unassociate(
+                self.id,
+                criteria=criteria,
+                limit=kwargs.get("limit"),
+            )
+        )
 
     @classmethod
     def from_data(cls, data):

--- a/tests/fake/test_fake_remove_content.py
+++ b/tests/fake/test_fake_remove_content.py
@@ -30,6 +30,37 @@ def test_can_remove_empty():
     assert not task.units
 
 
+def test_limited_remove_content():
+    """repo.remove() can remove a limited number of units."""
+    controller = FakeController()
+    client = controller.client
+
+    rpm_units = [
+        RpmUnit(name="gliba", version="1.0", release="1", arch="x86_64"),
+        RpmUnit(name="glibb", version="1.0", release="1", arch="x86_64"),
+        RpmUnit(name="glibc", version="1.0", release="1", arch="x86_64"),
+        RpmUnit(name="glibd", version="1.0", release="1", arch="x86_64"),
+    ]
+
+    repo = YumRepository(id="repo1")
+    controller.insert_repository(repo)
+    controller.insert_units(repo, rpm_units)
+
+    remove_rpms = client.get_repository("repo1").remove_content(
+        type_ids=["rpm"], limit=3
+    )
+
+    assert len(remove_rpms) == 1
+    task = remove_rpms[0]
+
+    # It should have completed successfully
+    assert task.completed
+    assert task.succeeded
+
+    # It should have removed (only) RPM units
+    assert len(task.units) == 3
+
+
 def test_can_remove_content():
     """repo.remove() succeeds and removes expected units inserted via controller."""
     controller = FakeController()


### PR DESCRIPTION
We want to perform garbage collection in batches to reduce the amount of resources it consumes and avoid out of memory exceptions. Unit association criteria has a limit field which we could use for batching requests.