### PR TITLE
Don't remove ISOs w/o version from mappings [RHELDST-21014]

### DIFF
--- a/pubtools/pulplib/_impl/client/ud_mappings.py
+++ b/pubtools/pulplib/_impl/client/ud_mappings.py
@@ -185,12 +185,12 @@ def update_mappings_for_files(mappings, file_page):
     # Returns Future[mappings] once all pages are processed.
 
     for unit in file_page.data:
+        # Save all the files for which the mapping should exist
+        mappings.filenames_from_pulp.append(unit.path)
         version = unit.version
         if version:
             # Add missing mappings
             mappings.set_file_mapping(version, unit.path, unit.display_order)
-            # Save all the files for which the mapping should exist
-            mappings.filenames_from_pulp.append(unit.path)
 
     if not file_page.next:
         # All pages have been processed, remove mappings for files which were not listed.

--- a/tests/repository/test_ud_mappings.py
+++ b/tests/repository/test_ud_mappings.py
@@ -73,7 +73,6 @@ def test_publish_update_mappings(fast_poller, requests_mocker, client, caplog):
                             "name": "file3",
                             "size": 1,
                             "checksum": "cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411",
-                            "pulp_user_metadata": {"version": "3.0"},
                         }
                     },
                 ]
@@ -169,7 +168,7 @@ def test_publish_update_mappings(fast_poller, requests_mocker, client, caplog):
             {"filename": "file5", "order": 4.5},
         ],
         # This wasn't touched because, although the repo has the file, it has no
-        # defined order
+        # defined version or order
         "3.0": [{"filename": "file3", "order": 1234}],
         # This was updated
         "4.0": [{"filename": "file4", "order": -2.0}],


### PR DESCRIPTION
Recent commit 92399ba introduced code for removal of deleted ISOs from `ud_file_release_mappings_2` repo note. The line of code collecting ISO filenames present in the repo has been put under the conditional on "version", however not every file has this field populated, which resulted in loss of mapping for all the files where the filed wasn't set. This commit amends that code, so the ISO filename is collected regardless of whether it has the version set.