### PR TITLE
Fix the wrong validator of ModulemdUnit.profiles [RHELDST-22116]

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -9,7 +9,7 @@ from ..convert import (
     frozenlist_or_none_sorted_converter,
     frozendict_or_none_converter,
 )
-from ..validate import optional_list_of, optional_dict
+from ..validate import optional_list_of, optional_frozendict
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -136,7 +136,7 @@ class ModulemdUnit(Unit):
         type=dict,
         pulp_field="profiles",
         default=None,
-        validator=optional_dict,
+        validator=optional_frozendict,
         converter=frozendict_or_none_converter,
     )
     """The profiles of this modulemd unit."""


### PR DESCRIPTION
Currently, the wrong validator resulted in a TypeError, saying pubtools-pulplib is validating the after-conversion "profiles" field as a dict:

TypeError: "'profiles' must be <class 'dict'>
(got frozendict.frozendict({'test': ['secondRepoRPM']}) that is a <class 'frozendict.frozendict'>)."

The validator of ModulemdUnit.profiles should be a frozendict rather than a dict after the "converter=frozenlist_or_none_converter" conversion.