### PR TITLE
Add Client.create_repository() [RHELDST-22483]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Added `Client.create_repository()` method
 
 ## [2.38.1] - 2023-12-14
 

--- a/docs/api/files.rst
+++ b/docs/api/files.rst
@@ -14,6 +14,8 @@ Repository
 .. autoclass:: pubtools.pulplib.FileSyncOptions()
    :members:
 
+.. autoclass:: pubtools.pulplib.FileImporter()
+   :members:
 
 Units
 -----

--- a/docs/api/pulpcore.rst
+++ b/docs/api/pulpcore.rst
@@ -27,6 +27,8 @@ Repository
 .. autoclass:: pubtools.pulplib.SyncOptions()
    :members:
 
+.. autoclass:: pubtools.pulplib.Importer()
+   :members:
 
 Units
 -----

--- a/docs/api/yum.rst
+++ b/docs/api/yum.rst
@@ -14,6 +14,8 @@ Repository
 .. autoclass:: pubtools.pulplib.YumSyncOptions()
    :members:
 
+.. autoclass:: pubtools.pulplib.YumImporter()
+   :members:
 
 Units: RPM
 ----------

--- a/pubtools/pulplib/__init__.py
+++ b/pubtools/pulplib/__init__.py
@@ -31,5 +31,8 @@ from ._impl.model import (
     Task,
     MaintenanceReport,
     MaintenanceEntry,
+    Importer,
+    YumImporter,
+    FileImporter,
 )
 from ._impl.fake import FakeController

--- a/pubtools/pulplib/_impl/client/retry.py
+++ b/pubtools/pulplib/_impl/client/retry.py
@@ -29,8 +29,8 @@ class PulpRetryPolicy(RetryPolicy):
 
         exception = future.exception()
         if exception and getattr(exception, "response", None) is not None:
-            # if returned status code is 404, never retry on that
-            if exception.response.status_code == 404:
+            # if returned status code is 404 or 409, never retry on that
+            if exception.response.status_code in (404, 409):
                 return False
 
         if exception and retry:

--- a/pubtools/pulplib/_impl/fake/client.py
+++ b/pubtools/pulplib/_impl/fake/client.py
@@ -651,3 +651,12 @@ class FakeClient(object):  # pylint:disable = too-many-instance-attributes
             self._state.sync_history.append(Sync(repo_f.result(), [task], sync_config))
 
         return f_return([task])
+
+    def create_repository(self, repo):
+        with self._state.lock:
+            if repo.id not in [
+                existing_repo.id for existing_repo in self._state.repositories
+            ]:
+                self._state.repositories.append(repo)
+
+        return self.get_repository(repo.id)

--- a/pubtools/pulplib/_impl/model/__init__.py
+++ b/pubtools/pulplib/_impl/model/__init__.py
@@ -9,6 +9,9 @@ from .repository import (
     FileSyncOptions,
     ContainerSyncOptions,
     YumSyncOptions,
+    Importer,
+    FileImporter,
+    YumImporter,
 )
 from .unit import (
     Unit,

--- a/pubtools/pulplib/_impl/model/common.py
+++ b/pubtools/pulplib/_impl/model/common.py
@@ -234,3 +234,15 @@ class Deletable(WithClient):
         delete_f = client._delete_resource(resource_type, resource_id)
         delete_f = f_map(delete_f, self.__detach)
         return f_proxy(delete_f)
+
+
+def schemaless_init(cls, data):
+    # Construct and return an instance of (attrs-using) cls from
+    # pulp data, where data in pulp has no schema at all (and hence
+    # every field could possibly be missing).
+    kwargs = {}
+    for key in [fld.name for fld in attr.fields(cls)]:
+        if key in data:
+            kwargs[key] = data[key]
+
+    return cls(**kwargs)

--- a/pubtools/pulplib/_impl/model/repository/__init__.py
+++ b/pubtools/pulplib/_impl/model/repository/__init__.py
@@ -1,4 +1,4 @@
-from .base import Repository, PublishOptions, SyncOptions
+from .base import Repository, PublishOptions, SyncOptions, Importer
 from .container import ContainerImageRepository, ContainerSyncOptions
-from .yum import YumRepository, YumSyncOptions
-from .file import FileRepository, FileSyncOptions
+from .yum import YumRepository, YumSyncOptions, YumImporter
+from .file import FileRepository, FileSyncOptions, FileImporter

--- a/pubtools/pulplib/_impl/model/repository/file.py
+++ b/pubtools/pulplib/_impl/model/repository/file.py
@@ -4,13 +4,23 @@ import logging
 from attr import validators
 from frozenlist2 import frozenlist
 
-from .base import Repository, SyncOptions, repo_type
+from .base import Repository, SyncOptions, repo_type, Importer
 from ...model.unit import FileUnit
 from ..attr import pulp_attrib
 from ... import compat_attr as attr
 
 
 LOG = logging.getLogger("pubtools.pulplib")
+
+
+@attr.s(kw_only=True, frozen=True)
+class FileImporter(Importer):
+    type_id = pulp_attrib(
+        default="iso_importer", type=str, pulp_field="importer_type_id"
+    )
+    """
+    Specific importer_type_id for File repositories.
+    """
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -48,6 +58,19 @@ class FileRepository(Repository):
         type=list,
         converter=frozenlist,
     )
+
+    importer = pulp_attrib(
+        default=FileImporter(),
+        type=FileImporter,
+        pulp_field="importers",
+        pulp_py_converter=FileImporter._from_data,
+        py_pulp_converter=FileImporter._to_data,
+    )
+    """
+    An object of :class:`~pubtools.pulplib.FileImporter` that is associated with the repository.
+
+    .. versionadded:: 2.39.0 
+    """
 
     def upload_file(self, file_obj, relative_url=None, **kwargs):
         """Upload a file to this repository.

--- a/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/pubtools/pulplib/_impl/model/repository/yum.py
@@ -3,12 +3,22 @@ import re
 from frozenlist2 import frozenlist
 
 from more_executors.futures import f_map, f_proxy, f_return, f_zip, f_flat_map
-from .base import Repository, SyncOptions, repo_type
+from .base import Repository, SyncOptions, repo_type, Importer
 from ..attr import pulp_attrib
 from ..common import DetachedException
 from ...model.unit import RpmUnit
 from ... import compat_attr as attr, comps
 from ...criteria import Criteria, Matcher
+
+
+@attr.s(kw_only=True, frozen=True)
+class YumImporter(Importer):
+    type_id = pulp_attrib(
+        default="yum_importer", type=str, pulp_field="importer_type_id"
+    )
+    """
+    Specific importer_type_id for Yum repositories.
+    """
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -102,6 +112,19 @@ class YumRepository(Repository):
         default=None, type=str, pulp_field="notes.ubi_config_version"
     )
     """Version of UBI config that should be used for population of this repository."""
+
+    importer = pulp_attrib(
+        default=YumImporter(),
+        type=YumImporter,
+        pulp_field="importers",
+        pulp_py_converter=YumImporter._from_data,
+        py_pulp_converter=YumImporter._to_data,
+    )
+    """
+    An object of :class:`~pubtools.pulplib.YumImporter` that is associated with the repository.
+
+    .. versionadded:: 2.39.0
+    """
 
     def get_binary_repository(self):
         """Find and return the binary repository relating to this repository.

--- a/pubtools/pulplib/_impl/model/unit/base.py
+++ b/pubtools/pulplib/_impl/model/unit/base.py
@@ -139,15 +139,3 @@ class Unit(PulpObject):
             )
 
         return out
-
-
-def schemaless_init(cls, data):
-    # Construct and return an instance of (attrs-using) cls from
-    # pulp data, where data in pulp has no schema at all (and hence
-    # every field could possibly be missing).
-    kwargs = {}
-    for key in [fld.name for fld in attr.fields(cls)]:
-        if key in data:
-            kwargs[key] = data[key]
-
-    return cls(**kwargs)

--- a/pubtools/pulplib/_impl/model/unit/erratum.py
+++ b/pubtools/pulplib/_impl/model/unit/erratum.py
@@ -1,8 +1,9 @@
 from frozenlist2 import frozenlist
 
-from .base import Unit, PulpObject, unit_type, schemaless_init
+from .base import Unit, PulpObject, unit_type
 
 from ..attr import pulp_attrib
+from ..common import schemaless_init
 from ... import compat_attr as attr
 from ..validate import (
     optional_bool,

--- a/pubtools/pulplib/_impl/model/unit/modulemd.py
+++ b/pubtools/pulplib/_impl/model/unit/modulemd.py
@@ -1,8 +1,9 @@
 import re
 
-from .base import Unit, unit_type, schemaless_init
+from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
+from ..common import schemaless_init
 from ... import compat_attr as attr
 from ..convert import (
     frozenlist_or_none_converter,

--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -1,9 +1,10 @@
 import datetime
 
 from pubtools.pulplib._impl.model.validate import optional_list_of
-from .base import Unit, unit_type, schemaless_init
+from .base import Unit, unit_type
 
 from ..attr import pulp_attrib
+from ..common import schemaless_init
 from ... import compat_attr as attr
 from ..convert import (
     frozenlist_or_none_converter,

--- a/pubtools/pulplib/_impl/schema/repository.yaml
+++ b/pubtools/pulplib/_impl/schema/repository.yaml
@@ -69,7 +69,9 @@ properties:
       # Note that this field is not set by Pulp itself.  Only certain tools
       # are expected to initialize this field when creating a repo.
       created:
-        type: string
+        anyOf:
+        - type: "null"
+        - type: string
         # example: 2019-06-05T11:56:50Z
         pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
 
@@ -100,7 +102,9 @@ properties:
 
       # Version of ubi config that should be used for population of this repository
       ubi_config_version:
-        type: string
+        anyOf:
+        - type: "null"
+        - type: string
 
       # Flag indicating whether the repository is visible in production instance
       # of download service. Stored as string.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.38.1",
+    version="2.39.0",
     packages=find_packages(exclude=["tests"]),
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},
     url="https://github.com/release-engineering/pubtools-pulplib",

--- a/tests/fake/test_fake_create_repo.py
+++ b/tests/fake/test_fake_create_repo.py
@@ -1,0 +1,16 @@
+from pubtools.pulplib import FakeController, Repository
+
+
+def test_create_repository():
+    """Client.create_repository() with fake client adds new repositories to controller."""
+    controller = FakeController()
+
+    client = controller.client
+    repo_1 = client.create_repository(Repository(id="repo1"))
+    repo_2 = client.create_repository(Repository(id="repo2"))
+
+    # adding already existing repository has no effect
+    _ = client.create_repository(Repository(id="repo1"))
+    # The change should be reflected in the controller,
+    # with two repositories present
+    assert controller.repositories == [repo_1.result(), repo_2.result()]


### PR DESCRIPTION
`Client` is now capable of creating a repository on pulp
server. The repository is initialized with proper `Importer` in order
to enable sync/upload of content to new repositories.

Another notable changes:
* 409 status is not retried in requests as it is used as indicator of
 existing repository.
* Added create_repository() method to FakeClient as well.
* Small changes in the repository.yaml schema as some of the fields
  don't have to be necessarily initialized when creating repo but can be
  updated later.
* Added `Importer` pulp object mapping class and related subclasses
  that encapsulate minimal required fields for this object with valid
  defaults.
* added `"importers": True` to search options for repos
* fixed converter of `notes.signatures` on `Repository` - empty string is now
  converted to empty list, not to list with empty string