### PR TITLE
Add files attribute to RpmUnit [RHELDST-21555]

### DIFF
--- a/pubtools/pulplib/_impl/model/unit/rpm.py
+++ b/pubtools/pulplib/_impl/model/unit/rpm.py
@@ -1,19 +1,18 @@
 import datetime
 
 from pubtools.pulplib._impl.model.validate import optional_list_of
-from .base import Unit, unit_type
 
-from ..attr import pulp_attrib
-from ..common import schemaless_init
 from ... import compat_attr as attr
+from ..attr import pulp_attrib
+from ..common import PulpObject, schemaless_init
 from ..convert import (
     frozenlist_or_none_converter,
     frozenlist_or_none_sorted_converter,
-    tolerant_timestamp,
     timestamp_converter,
+    tolerant_timestamp,
 )
-from ..validate import optional_str, instance_of
-from ..common import PulpObject
+from ..validate import instance_of, optional_str
+from .base import Unit, unit_type
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -236,6 +235,17 @@ class RpmUnit(Unit):
     )
     """
     List of capabilities that this RPM provides or ``None`` if this information is unavailable.
+    """
+
+    files = pulp_attrib(
+        default=None,
+        type=list,
+        converter=frozenlist_or_none_converter,
+        pulp_field="files.file",
+        validator=optional_list_of(str),
+    )
+    """
+    List of files that this RPM provides or ``None`` if this information is unavailable.
     """
 
     @md5sum.validator

--- a/tests/unit/test_rpm_deps.py
+++ b/tests/unit/test_rpm_deps.py
@@ -29,7 +29,11 @@ def test_rpm_requires_provides():
                     "release": "1",
                     "epoch": "0",
                     "flags": "LT",
-                }
+                },
+                # We should also expect inclusion of files/scriptlets in requires.
+                {
+                    "name": "/some/script.sh",
+                },
             ],
         }
     )
@@ -42,10 +46,12 @@ def test_rpm_requires_provides():
     provides_item.epoch == "0"
     provides_item.flags == "EQ"
 
-    assert len(unit.requires) == 1
+    assert len(unit.requires) == 2
     requires_item = unit.requires[0]
     requires_item.name == "test-requires"
     requires_item.version == "1.0"
     requires_item.release == "1"
     requires_item.epoch == "0"
     requires_item.flags == "LT"
+    requires_item = unit.requires[1]
+    requires_item.name == "/some/script.sh"

--- a/tests/unit/test_rpm_unit.py
+++ b/tests/unit/test_rpm_unit.py
@@ -19,6 +19,12 @@ def test_user_metadata_fields():
                 "cdn_path": "/some/path/to/my.rpm",
                 "cdn_published": "2021-04-01T01:08:26",
             },
+            "files": {
+                "file": [
+                    "/usr/bin/some/script.sh",
+                    "/usr/bin/another/script/provided.py",
+                ],
+            },
         }
     )
 
@@ -32,6 +38,7 @@ def test_user_metadata_fields():
         content_type_id="rpm",
         cdn_path="/some/path/to/my.rpm",
         cdn_published=datetime.datetime(2021, 4, 1, 1, 8, 26),
+        files=["/usr/bin/some/script.sh", "/usr/bin/another/script/provided.py"],
     )
 
 


### PR DESCRIPTION
This commit adds an attribute, files, to RpmUnit which maps to the 'files.file' pulp field and holds a list of files provided by the RPM.

The immediate use case for this is in ubi-manifest to identify available files which may match those listed as dependencies, avoiding unnecessary pulp searches.