### PR TITLE
Improve `Repository` attrs [RHELDST-22483]

### DIFF
--- a/pubtools/pulplib/_impl/model/repository/base.py
+++ b/pubtools/pulplib/_impl/model/repository/base.py
@@ -4,7 +4,8 @@ import warnings
 import json
 from functools import partial
 
-from attr import validators, asdict
+from attr import validators, asdict, converters
+
 from frozenlist2 import frozenlist
 from more_executors.futures import f_proxy, f_map, f_flat_map
 
@@ -247,8 +248,8 @@ class Repository(PulpObject, Deletable):
         default=None,
         type=int,
         pulp_field="notes.eng_product",
-        pulp_py_converter=int,
-        py_pulp_converter=str,
+        pulp_py_converter=converters.optional(int),
+        py_pulp_converter=converters.optional(str),
     )
     """ID of the product to which this repository belongs (if any)."""
 

--- a/pubtools/pulplib/_impl/schema/repository.yaml
+++ b/pubtools/pulplib/_impl/schema/repository.yaml
@@ -98,7 +98,9 @@ properties:
 
       # Name of content set that is associated with this repository
       content_set:
-        type: string
+        anyOf:
+        - type: "null"
+        - type: string
 
       # Version of ubi config that should be used for population of this repository
       ubi_config_version:


### PR DESCRIPTION
* `content_set` was made properly optional via schema update
* fix converters for `eng_product_id` which now properly handle `None`  value when converting from or to pulp.