### PR TITLE
Added support for Distributor when creating repository

### DIFF
--- a/tests/fake/test_fake_create_repo.py
+++ b/tests/fake/test_fake_create_repo.py
@@ -1,4 +1,4 @@
-from pubtools.pulplib import FakeController, Repository
+from pubtools.pulplib import FakeController, Repository, Distributor
 
 
 def test_create_repository():
@@ -6,11 +6,26 @@ def test_create_repository():
     controller = FakeController()
 
     client = controller.client
-    repo_1 = client.create_repository(Repository(id="repo1"))
-    repo_2 = client.create_repository(Repository(id="repo2"))
+    repo_1 = client.create_repository(
+        Repository(
+            id="repo1",
+            distributors=[Distributor(id="dist1", type_id="yum_distributor")],
+        )
+    )
+    repo_2 = client.create_repository(
+        Repository(
+            id="repo2",
+            distributors=[Distributor(id="dist2", type_id="yum_distributor")],
+        )
+    )
 
     # adding already existing repository has no effect
-    _ = client.create_repository(Repository(id="repo1"))
+    _ = client.create_repository(
+        Repository(
+            id="repo1",
+            distributors=[Distributor(id="dist1", type_id="yum_distributor")],
+        )
+    )
     # The change should be reflected in the controller,
     # with two repositories present
     assert controller.repositories == [repo_1.result(), repo_2.result()]


### PR DESCRIPTION
Previously it wasn't possible to create repository with distributor because of inconsintent naming of various fields which resulted in Bad requests.

This is now fixed and distributors can be created along repository. Only mininal configuration is currently supported.