### PR TITLE
ci: drop codecov

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -51,18 +51,6 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
-
-      # Codcov Action required installing pytest-cov as it needs coverage.
-      # The coverage library installed within tox is in virt-env and not 
-      # accessible to Codecov.
-      - name: Install pytest cov
-        run: pip install pytest-cov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          verbose: true
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A Python client for [Pulp 2.x](https://pulpproject.org/), used by
 [release-engineering](https://github.com/release-engineering) publishing tools.
 
 [![Build Status](https://github.com/release-engineering/pubtools-pulplib/actions/workflows/tox-test.yml/badge.svg)](https://github.com/release-engineering/pubtools-pulplib/actions/workflows/tox-test.yml)
-[![codecov](https://codecov.io/gh/release-engineering/pubtools-pulplib/branch/master/graph/badge.svg?token=CABMY3WeIB)](https://codecov.io/gh/release-engineering/pubtools-pulplib)
 
 - [Source](https://github.com/release-engineering/pubtools-pulplib)
 - [Documentation](https://release-engineering.github.io/pubtools-pulplib/)


### PR DESCRIPTION
The test coverage for this project is already locked at 100% via `--cov-fail-under=100`, so codecov is not bringing much value. At the same time it's a frequent point of failure (mainly around credentials management), so just drop it.