### PR TITLE
Fixes matching to all when searching content in the fake client

### DIFF
--- a/src/pubtools/pulplib/_impl/fake/match.py
+++ b/src/pubtools/pulplib/_impl/fake/match.py
@@ -123,6 +123,8 @@ def match_field_exists(_matcher, field, obj):
 @visit(InMatcher)
 def match_in(matcher, field, obj):
     value = get_field(field, obj)
+    if field == "content_type_id" and not matcher._values:
+        return True
     for elem in matcher._values:
         if elem == value:
             return True

--- a/tests/fake/test_fake_search_content.py
+++ b/tests/fake/test_fake_search_content.py
@@ -327,3 +327,12 @@ def test_search_content_files(populated_repo):
             files=["/some/file", "/another/file", "/yet/another/file", "/script"],
         )
     ]
+
+
+def test_search_content_all_type_ids(populated_repo):
+    """search_content with field content_type_ids and []"""
+
+    crit = Criteria.with_field_in("content_type_id", [])
+    units = list(populated_repo.search_content(crit))
+
+    assert len(units) == 7


### PR DESCRIPTION
Adds ability to accept [] for all when using In matching criteria. This brings fake client in line with the regular client. Current implementation returns nothing if using "[]" using the fake client vs. the full list of items using the real client.

Refers to: RHELDST-29112