### PR TITLE
Reimplement naturalsize as part of pubtools-pulplib [RHELDST-29440]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ attrs
 frozenlist2
 frozendict; python_version >= '3.6'
 pubtools>=0.3.0
-humanize
 monotonic; python_version < '3.3'

--- a/src/pubtools/pulplib/_impl/client/client.py
+++ b/src/pubtools/pulplib/_impl/client/client.py
@@ -24,12 +24,11 @@ from ..model import (
     Task,
 )
 from ..log import TimedLogger
-from ..util import dict_put
+from ..util import dict_put, naturalsize
 from .search import search_for_criteria
 from .errors import PulpException
 from .poller import TaskPoller
 from . import retry
-from humanize import naturalsize
 
 from .ud_mappings import compile_ud_mappings
 from .copy import CopyOptions

--- a/src/pubtools/pulplib/_impl/util.py
+++ b/src/pubtools/pulplib/_impl/util.py
@@ -1,4 +1,5 @@
 ABSENT = object()
+SUFFIXES = ("k", "M", "G", "T", "P", "E")
 
 
 def lookup(value, key, default=ABSENT):
@@ -47,3 +48,30 @@ def dict_put(out, key, value):
         else:
             # Not the last key, so ensure there's a sub-dict.
             out = out.setdefault(next_key, {})
+
+
+def naturalsize(value):
+    """
+    Format a number of bytes like a human-readable filesize.
+    Uses SI system (metric), so e.g. 10000 B = 10 kB.
+    """
+    base = 1000
+
+    if isinstance(value, str):
+        size_bytes = float(value)
+    else:
+        size_bytes = value
+    abs_bytes = abs(size_bytes)
+
+    if abs_bytes == 1:
+        return f"{size_bytes} Byte"
+    if abs_bytes < base:
+        return f"{int(size_bytes)} Bytes"
+
+    suffix = ""
+    for power, suffix in enumerate(SUFFIXES, 2):
+        unit = base**power
+        if abs_bytes < unit:
+            break
+    size_natural = base * (size_bytes / unit)
+    return f"{size_natural:.1f} {suffix}B"

--- a/tests/util/test_naturalsize.py
+++ b/tests/util/test_naturalsize.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pubtools.pulplib._impl.util import naturalsize
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        (1, "1 Byte"),
+        ("10", "10 Bytes"),
+        (1234, "1.2 kB"),
+        (1234567, "1.2 MB"),
+        (678909876543, "678.9 GB"),
+        (1000000000000, "1.0 TB"),
+        ("874365287928728746529431", "874365.3 EB"),
+    ],
+)
+def test_naturalsize(input, output):
+    """
+    Format a number of bytes like a human-readable filesize.
+    """
+    assert naturalsize(input) == output


### PR DESCRIPTION
This commit pulls out the `naturalsize()` function from humanize module and reimplements its equivalent in pubtools-pulplib. The humanize module is then removed from dependencies as it's not used anywhere else. This is done to reduce the dependency bloat and make the RPM packaging easier on RHEL 9 which doesn't ship python-humanize.