### PR TITLE
Temporary fix for `ubi_config_version` attr

### DIFF
--- a/src/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/src/pubtools/pulplib/_impl/model/repository/yum.py
@@ -113,7 +113,7 @@ class YumRepository(Repository):
     )
 
     ubi_config_version = pulp_attrib(
-        default=None,
+        default="",
         type=str,
         pulp_field="notes.ubi_config_version",
         mutable=True,


### PR DESCRIPTION
* the default value of `ubi_config_version` set to None may cause error when repository is updated on pulp server because pulp  would try to remove non-existent repo note which will fail with KeyError
* let's set this repo note default value to empty string temporarily as the fix should actually be done on pulp
* can/should be reverted as soon as pulp fix is deployed