### PR TITLE
Map skip YumSyncOption to type_skip_list [ROK-1828]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- YumSyncOption's `skip` parameter is now correctly passed to the rhsm-pulp API as `type_skip_list`
 
 ## [2.43.2] - 2026-01-21
 

--- a/src/pubtools/pulplib/_impl/model/repository/base.py
+++ b/src/pubtools/pulplib/_impl/model/repository/base.py
@@ -4,7 +4,7 @@ import warnings
 import json
 from functools import partial
 
-from attr import validators, asdict, converters
+from attr import validators, converters
 
 from frozenlist2 import frozenlist
 from more_executors.futures import f_proxy, f_map, f_flat_map
@@ -651,11 +651,16 @@ class Repository(PulpObject, Deletable):
         if not self._client:
             raise DetachedException()
 
-        return f_proxy(
-            self._client._do_sync(
-                self.id, asdict(options, filter=lambda name, val: val is not None)
-            )
-        )
+        # Convert sync options to dict, respecting pulp_field metadata
+        sync_config = {}
+        for field in attr.fields(type(options)):
+            value = getattr(options, field.name)
+            if value is not None:
+                # Use pulp_field if available, otherwise use field name
+                pulp_field = field.metadata.get(PULP2_FIELD, field.name)
+                sync_config[pulp_field] = value
+
+        return f_proxy(self._client._do_sync(self.id, sync_config))
 
     def lock(self, context, duration=None):
         """

--- a/src/pubtools/pulplib/_impl/model/repository/yum.py
+++ b/src/pubtools/pulplib/_impl/model/repository/yum.py
@@ -43,7 +43,7 @@ class YumSyncOptions(SyncOptions):
     """Count indicating how many old rpm versions to retain.
     """
 
-    skip = pulp_attrib(default=None, type=list)
+    skip = pulp_attrib(default=None, type=list, pulp_field="type_skip_list")
     """List of content types to be skipped during the repository synchronization
     """
 

--- a/tests/repository/test_sync.py
+++ b/tests/repository/test_sync.py
@@ -60,7 +60,9 @@ def test_sync_with_options(
     repo = YumRepository(id="some-repo")
     repo.__dict__["_client"] = client
 
-    options = YumSyncOptions(ssl_validation=False, feed="mock://example.com/")
+    options = YumSyncOptions(
+        ssl_validation=False, feed="mock://example.com/", skip=["drpm", "srpm"]
+    )
 
     # It should have succeeded, with the tasks as retrieved from Pulp
     assert repo.sync(options).result() == [
@@ -72,4 +74,6 @@ def test_sync_with_options(
     assert req[0].json()["override_config"] == {
         "ssl_validation": False,
         "feed": "mock://example.com/",
+        # Verify that 'skip' is passed as 'type_skip_list' in the API call
+        "type_skip_list": ["drpm", "srpm"],
     }


### PR DESCRIPTION
The skip option for yum repo sync was passed to the rhsm-pulp API as 'skip', but the rhsm-pulp API expects 'type_skip_list'.

To correct the disparity, YumSyncOption's 'skip' attribute has been mapped to 'type_skip_list' via the 'pulp_field' parameter, and the sync method has been updated to respect 'pulp_field' metadata when converting sync options to rhsm-pulp API parameters.