### PR TITLE
Add pulp3 client [RHELDST-38334]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added pulp3 client
+
 ## [2.43.3] - 2026-06-01
 
 ### Fixed

--- a/docs/api/client_pulp3.rst
+++ b/docs/api/client_pulp3.rst
@@ -1,0 +1,15 @@
+API: client for Pulp 3
+======================
+
+.. autoclass:: pubtools.pulplib.Pulp3Client
+   :members:
+
+Errors
+------
+
+.. autoclass:: pubtools.pulplib.Pulp3Exception
+   :members:
+
+.. autoclass:: pubtools.pulplib.Pulp3TaskException
+   :members:
+        

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ A Pulp library for publishing tools.
    :caption: Contents:
 
    api/client
+   api/client_pulp3
    api/pulpcore
    api/yum
    api/files

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ frozendict; python_version >= '3.6'
 pubtools>=0.3.0
 monotonic; python_version < '3.3'
 defusedxml
+httpx
+tenacity
+anyio[trio]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulplib",
-    version="2.43.3",
+    version="2.44.0",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     package_data={"pubtools.pulplib._impl.schema": ["*.yaml"]},

--- a/src/pubtools/pulplib/__init__.py
+++ b/src/pubtools/pulplib/__init__.py
@@ -1,4 +1,5 @@
 from ._impl.client import Client, PulpException, TaskFailedException, CopyOptions
+from ._impl.client_pulp3 import Pulp3Client, Pulp3Exception, Pulp3TaskException
 from ._impl.criteria import Criteria, Matcher
 from ._impl.page import Page
 from ._impl.model import (

--- a/src/pubtools/pulplib/_impl/client_pulp3/__init__.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/__init__.py
@@ -1,0 +1,2 @@
+from .client import Pulp3Client
+from .errors import Pulp3Exception, Pulp3TaskException

--- a/src/pubtools/pulplib/_impl/client_pulp3/client.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/client.py
@@ -1,0 +1,411 @@
+# Generated-by: Claude Code
+
+from json import JSONDecodeError
+import logging
+import os
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+import anyio
+import httpx
+from .errors import Pulp3TaskException
+from .retry import get_retry_policy
+
+LOG = logging.getLogger("pubtools.pulplib")
+
+
+class Pulp3Client:
+    """An async client for the Pulp 3.x API.
+
+    This class provides high-level async methods for querying a Pulp 3 server
+    and performing actions in Pulp.
+
+    **Usage:**
+
+    This client is designed to be used as an async context manager with AnyIO's
+    Trio backend:
+
+    .. code-block:: python
+
+        async with Pulp3Client(url="https://pulp.example.com/") as client:
+            repo = await client.create_repository("test-repo")
+            print(repo["name"])
+
+    **Backend:**
+
+    The client uses:
+    - AnyIO with Trio backend for structured concurrency
+    - httpx for async HTTP requests
+    - Task groups for managing concurrent operations
+
+    **Rate Limiting:**
+
+    The client supports automatic rate limiting to avoid overwhelming the server.
+    """
+
+    _DEFAULT_TIMEOUT = 120.0
+    _MAX_CONCURRENT_REQUESTS = int(
+        os.environ.get("PUBTOOLS_PULPLIB_MAX_CONCURRENT_REQUESTS", "10")
+    )
+
+    def __init__(
+        self,
+        url: str,
+        auth: Optional[tuple] = None,
+        cert: Optional[str] = None,
+        verify: bool = True,
+        timeout: Optional[float] = None,
+        max_retries: int = 5,
+        retry_min_wait: float = 1.0,
+        retry_max_wait: float = 60.0,
+        domain: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            url: URL of a Pulp 3 server, e.g. https://pulp.example.com/
+            auth: Optional tuple of (username, password) for authentication
+            cert: Optional path to client certificate file
+            verify: Whether to verify SSL certificates (default: True)
+            timeout: Request timeout in seconds (default: 120.0)
+            max_retries: Maximum retry attempts for failed requests (default: 5)
+            retry_min_wait: Minimum wait between retries in seconds (default: 1.0)
+            retry_max_wait: Maximum wait between retries in seconds (default: 60.0)
+            domain: Pulp domain name (default: from PULP_DOMAIN env or 'default')
+            **kwargs: Additional arguments passed to httpx.AsyncClient
+        """
+        # Set domain and API path
+        self._domain = domain or os.getenv("PULP_DOMAIN", "default")
+        self._api_path = f"/api/pulp/{self._domain}/api/v3/"
+
+        # Construct full API URL
+        self._url = urljoin(url.rstrip("/"), self._api_path)
+        self._auth = httpx.BasicAuth(*auth) if auth else None
+        self._cert = cert
+        self._verify = verify
+        self._timeout = timeout or self._DEFAULT_TIMEOUT
+        self._retry_policy = get_retry_policy(
+            max_attempts=max_retries,
+            min_wait=retry_min_wait,
+            max_wait=retry_max_wait,
+        )
+        self._client_kwargs = kwargs
+
+        self._client: Optional[httpx.AsyncClient] = None
+        self._limiter: Optional[anyio.CapacityLimiter] = None
+
+    async def __aenter__(self):
+        """Enter async context manager."""
+        self._limiter = anyio.CapacityLimiter(self._MAX_CONCURRENT_REQUESTS)
+
+        self._client = httpx.AsyncClient(
+            base_url=self._url,
+            auth=self._auth,
+            cert=self._cert,
+            verify=self._verify,
+            timeout=self._timeout,
+            **self._client_kwargs,
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit async context manager."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+        self._limiter = None
+
+    async def _do_request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        """Execute HTTP request without retry logic.
+
+        Args:
+            method: HTTP method
+            url: Full URL
+            **kwargs: Arguments for httpx request
+
+        Returns:
+            HTTP response
+        """
+        LOG.debug("%s %s", method, url)
+        response = await self._client.request(method, url, **kwargs)
+        LOG.debug("Response %s %s: %s", method, url, response.status_code)
+        response.raise_for_status()
+        return response
+
+    async def _request(
+        self, method: str, path: str, **kwargs
+    ) -> Optional[Dict[str, Any]]:
+        """Make an HTTP request to Pulp API with retry and rate limiting.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            path: API path (will be joined with base URL)
+            **kwargs: Additional arguments passed to httpx request
+
+        Returns:
+            Parsed JSON response, or None if resource not found (404)
+
+        Raises:
+            httpx.HTTPStatusError: For HTTP errors (except 404)
+            httpx.HTTPError: For network/connection errors
+            RuntimeError: If client not initialized
+        """
+        if not self._client:
+            raise RuntimeError(
+                "Client not initialized. Use 'async with' context manager."
+            )
+
+        url = urljoin(self._url + "/", path.lstrip("/"))
+
+        async with self._limiter:
+            try:
+                async for attempt in self._retry_policy:
+                    with attempt:
+                        response = await self._do_request(method, url, **kwargs)
+
+                        # Handle 204 No Content
+                        if response.status_code == 204:
+                            return None
+
+                        # Parse JSON response
+                        try:
+                            return response.json()
+                        except JSONDecodeError as e:
+                            LOG.error(
+                                "Failed to decode JSON from %s %s: %s", method, url, e
+                            )
+                            LOG.debug("Response body: %s", response.text[:500])
+                            raise
+
+            except httpx.HTTPStatusError as e:
+                # Handle 404 as a special case - resource not found is valid
+                if e.response.status_code == 404:
+                    LOG.debug("Resource not found: %s %s", method, url)
+                    return None
+                raise
+
+    async def get_status(self) -> Dict[str, Any]:
+        """Get Pulp server status.
+
+        Returns:
+            Dictionary containing server status information
+        """
+        return await self._request("GET", "/status/")
+
+    async def create_repository(self, name: str, **kwargs) -> Dict[str, Any]:
+        """Create a new repository.
+
+        Args:
+            name: Repository name
+            **kwargs: Additional repository attributes (description, retain_repo_versions, etc.)
+
+        Returns:
+            Created repository data
+        """
+        LOG.info("Creating repository: %s", name)
+        data = {"name": name, **kwargs}
+        path = "/repositories/rpm/rpm/"
+        result = await self._request("POST", path, json=data)
+        LOG.info("Repository created: %s (href: %s)", name, result.get("pulp_href"))
+        return result
+
+    async def poll_task(
+        self,
+        task_href_or_id: str,
+        poll_interval: float = 5.0,
+        timeout: float = 60.0 * 60,  # 1 hour
+    ) -> Dict[str, Any]:
+        """Poll a task until completion.
+
+        Args:
+            task_href_or_id: Task href (e.g., '/api/pulp/.../tasks/abc/') or task ID (e.g., 'abc')
+            poll_interval: Seconds between poll attempts (default: 5.0)
+            timeout: Maximum time to wait in seconds (default: 3600.0 / 1 hour)
+
+        Returns:
+            Completed task data dictionary
+
+        Raises:
+            Pulp3TaskException: If task fails or is canceled
+            TimeoutError: If timeout is exceeded
+        """
+        task_id = (
+            task_href_or_id.split("/")[-2]
+            if task_href_or_id.startswith("/api/")
+            else task_href_or_id
+        )
+
+        async def _poll():
+            while True:
+                task = await self._request("GET", f"/tasks/{task_id}/")
+                state = task.get("state")
+
+                if state == "completed":
+                    LOG.info("Task %s completed", task_id)
+                    return task
+                elif state in ("failed", "canceled"):
+                    error = task.get("error", {}).get("description", "Unknown error")
+                    LOG.error("Task %s %s: %s", task_id, state, error)
+                    raise Pulp3TaskException(f"Task {task_id} {state}: {error}")
+
+                LOG.debug("Task %s state: %s", task_id, state)
+                await anyio.sleep(poll_interval)
+
+        with anyio.fail_after(timeout):
+            return await _poll()
+
+    async def create_publication(self, repository_href: str, **kwargs) -> str:
+        """Create a publication for a repository.
+
+        Args:
+            repository_href: Repository href to publish
+            **kwargs: Additional publish options
+
+        Returns:
+            Task href string (e.g., '/api/pulp/.../tasks/abc/')
+
+        Raises:
+            httpx.HTTPStatusError: If request fails
+        """
+        LOG.info("Creating publication for repository: %s", repository_href)
+        data = {"repository": repository_href, **kwargs}
+        result = await self._request("POST", "/publications/rpm/rpm/", json=data)
+        LOG.debug("Publication task created: %s", result.get("task"))
+        return result.get("task")
+
+    async def modify_repo_content(
+        self,
+        repository_href_or_id: str,
+        add_content_units: Optional[list] = None,
+        remove_content_units: Optional[list] = None,
+    ) -> str:
+        """Modify repository content by adding or removing content units.
+
+        Args:
+            repository_href_or_id: Repository href (e.g., '/api/.../repositories/rpm/rpm/abc/')
+                                   or repository ID (e.g., 'abc')
+            add_content_units: List of content unit hrefs to add (default: None)
+            remove_content_units: List of content unit hrefs to remove (default: None)
+
+        Returns:
+            Task href string (e.g., '/api/pulp/.../tasks/xyz/')
+
+        Raises:
+            ValueError: If both add_content_units and remove_content_units are empty
+            httpx.HTTPStatusError: If request fails
+        """
+        LOG.info(
+            "Modifying repository content: %s (add: %d, remove: %d)",
+            repository_href_or_id,
+            len(add_content_units or []),
+            len(remove_content_units or []),
+        )
+        if not add_content_units and not remove_content_units:
+            raise ValueError(
+                f"No content to modify for repository: {repository_href_or_id}"
+            )
+
+        repository_id = (
+            repository_href_or_id.split("/")[-2]
+            if repository_href_or_id.startswith("/api/")
+            else repository_href_or_id
+        )
+        path = os.path.join(f"repositories/rpm/rpm/{repository_id}/", "modify/")
+
+        data = {
+            "add_content_units": add_content_units or [],
+            "remove_content_units": remove_content_units or [],
+        }
+        result = await self._request("POST", path, json=data)
+        LOG.debug("Content modification task created: %s", result.get("task"))
+        return result.get("task")
+
+    async def create_distribution(
+        self, repository_href: str, base_path: str, name: str
+    ) -> str:
+        """Create a distribution for a repository.
+
+        Args:
+            repository_href: Repository href to add distribution
+            base_path: Base path for the distribution (URL path component)
+            name: Name of the distribution
+
+        Returns:
+            Task href string (e.g., '/api/pulp/.../tasks/xyz/')
+
+        Raises:
+            httpx.HTTPStatusError: If request fails
+        """
+        LOG.info(
+            "Creating distribution: %s at %s for repository %s",
+            name,
+            base_path,
+            repository_href,
+        )
+        url = "/distributions/rpm/rpm/"
+        data = {
+            "base_path": base_path,
+            "name": name,
+            "repository": repository_href,
+        }
+
+        result = await self._request("POST", url, json=data)
+        LOG.debug("Distribution task created: %s", result.get("task"))
+        return result.get("task")
+
+    def build_query_sha256(self, checksums: list) -> str:
+        """Build a Pulp query for searching content by SHA256 checksums.
+
+        Args:
+            checksums: List of SHA256 checksum strings
+
+        Returns:
+            Query string suitable for search_content(), e.g., "(sha256=abc OR sha256=def)"
+
+        Example:
+            >>> client.build_query_sha256(["abc123", "def456"])
+            '(sha256=abc123 OR sha256=def456)'
+
+        Note:
+            This method will be refactored/reimplemented to support generic field queries in the future.
+        """
+        query = ""
+        for i, checksum in enumerate(checksums):
+            if i:
+                query += " OR "
+            query += f"sha256={checksum}"
+
+        query = f"({query})"
+
+        return query
+
+    async def search_content(
+        self,
+        query: str,
+        fields: Optional[list] = None,
+        offset: int = 0,
+        limit: int = 1000,
+    ) -> list:
+        """Search for RPM package content.
+
+        Args:
+            query: Query string (e.g., from build_query_sha256)
+            fields: Optional list of field names to return (default: all fields)
+            offset: Offset for pagination (default: 0)
+            limit: Limit for pagination (default: 1000)
+        Returns:
+            List of matching content unit dictionaries
+
+        Raises:
+            httpx.HTTPStatusError: If request fails
+
+        Note:
+            This method currently does not support pagination automatically.
+            Use offset/limit in params for manual pagination.
+        """
+        url = "content/rpm/packages/"
+        params = {"q": query, "offset": offset, "limit": limit}
+        if fields:
+            params["fields"] = ",".join(fields)
+        data = await self._request("GET", url, params=params)
+        return data.get("results", []) if data else []

--- a/src/pubtools/pulplib/_impl/client_pulp3/client.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/client.py
@@ -3,7 +3,7 @@
 from json import JSONDecodeError
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union, Tuple
 from urllib.parse import urljoin
 
 import anyio

--- a/src/pubtools/pulplib/_impl/client_pulp3/client.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/client.py
@@ -52,7 +52,7 @@ class Pulp3Client:
         self,
         url: str,
         auth: Optional[tuple] = None,
-        cert: Optional[str] = None,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
         verify: bool = True,
         timeout: Optional[float] = None,
         max_retries: int = 5,

--- a/src/pubtools/pulplib/_impl/client_pulp3/errors.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/errors.py
@@ -1,0 +1,7 @@
+# Generated-by: Claude Code
+class Pulp3Exception(Exception):
+    pass
+
+
+class Pulp3TaskException(Pulp3Exception):
+    pass

--- a/src/pubtools/pulplib/_impl/client_pulp3/retry.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/retry.py
@@ -1,0 +1,58 @@
+# Generated-by: Claude Code
+
+import logging
+
+import httpx
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+    before_sleep_log,
+)
+
+LOG = logging.getLogger("pubtools.pulplib")
+
+
+def should_retry_request(exception: Exception) -> bool:
+    """Determine if an HTTP request should be retried.
+
+    Args:
+        exception: Exception that occurred
+
+    Returns:
+        True if request should be retried
+    """
+    if isinstance(exception, httpx.HTTPStatusError):
+        status_code = exception.response.status_code
+        # Retry on timeout, rate limiting, and server errors
+        return status_code in (408, 429, 500, 502, 503, 504, 400)
+
+    if isinstance(exception, (httpx.TimeoutException, httpx.NetworkError)):
+        return True
+
+    return False
+
+
+def get_retry_policy(
+    max_attempts: int = 5,
+    min_wait: float = 1.0,
+    max_wait: float = 60.0,
+) -> AsyncRetrying:
+    """Create a tenacity retry policy for Pulp API requests.
+
+    Args:
+        max_attempts: Maximum number of retry attempts
+        min_wait: Minimum wait time between retries in seconds
+        max_wait: Maximum wait time between retries in seconds
+
+    Returns:
+        Configured AsyncRetrying instance
+    """
+    return AsyncRetrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(min=min_wait, max=max_wait),
+        retry=retry_if_exception(should_retry_request),
+        before_sleep=before_sleep_log(LOG, logging.WARNING),
+        reraise=True,
+    )

--- a/src/pubtools/pulplib/_impl/client_pulp3/retry.py
+++ b/src/pubtools/pulplib/_impl/client_pulp3/retry.py
@@ -26,7 +26,7 @@ def should_retry_request(exception: Exception) -> bool:
     if isinstance(exception, httpx.HTTPStatusError):
         status_code = exception.response.status_code
         # Retry on timeout, rate limiting, and server errors
-        return status_code in (408, 429, 500, 502, 503, 504, 400)
+        return status_code in (408, 429, 500, 502, 503, 504)
 
     if isinstance(exception, (httpx.TimeoutException, httpx.NetworkError)):
         return True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,9 @@
 pytest
+pytest-anyio
 requests-mock
 mock
 kobo
 koji
 rpmdyn
 bandit==1.7.5
+respx

--- a/tests/client_pulp3/__init__.py
+++ b/tests/client_pulp3/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for Pulp3Client.
+
+Test organization:
+- test_client_basic.py: Client initialization and context manager
+- test_client_requests.py: HTTP request methods
+- test_client_repositories.py: Repository operations
+- test_client_errors.py: Error handling
+- test_client_retry.py: Retry behavior
+- test_client_tasks.py: Task polling
+- test_client_distributions.py: Distribution operations
+- test_client_content.py: Content operations
+"""

--- a/tests/client_pulp3/conftest.py
+++ b/tests/client_pulp3/conftest.py
@@ -1,0 +1,55 @@
+"""
+Shared fixtures for Pulp3Client tests.
+Generated-by: Claude Code
+"""
+
+import pytest
+from pubtools.pulplib._impl.client_pulp3.client import Pulp3Client
+
+# Default test configuration
+TEST_PULP_URL = "https://pulp.example.com"
+TEST_DOMAIN = "test-domain"
+TEST_MAX_RETRIES = 1
+TEST_RETRY_MIN_WAIT = 0.001
+TEST_RETRY_MAX_WAIT = 0.01
+
+
+@pytest.fixture(autouse=True)
+def anyio_backend():
+    """Configure anyio backend for all tests."""
+    return "trio"
+
+
+@pytest.fixture
+def pulp3_client():
+    """Factory fixture for creating Pulp3Client with test defaults.
+
+    Returns a factory function that creates a client with fast retry settings.
+    Can be called with custom parameters to override defaults.
+
+    Usage:
+        async with pulp3_client() as client:
+            # use client
+
+        async with pulp3_client(max_retries=5) as client:
+            # use client with custom settings
+    """
+
+    def _create_client(
+        url=TEST_PULP_URL,
+        domain=TEST_DOMAIN,
+        max_retries=TEST_MAX_RETRIES,
+        retry_min_wait=TEST_RETRY_MIN_WAIT,
+        retry_max_wait=TEST_RETRY_MAX_WAIT,
+        **kwargs
+    ):
+        return Pulp3Client(
+            url=url,
+            domain=domain,
+            max_retries=max_retries,
+            retry_min_wait=retry_min_wait,
+            retry_max_wait=retry_max_wait,
+            **kwargs
+        )
+
+    return _create_client

--- a/tests/client_pulp3/test_client_basic.py
+++ b/tests/client_pulp3/test_client_basic.py
@@ -1,0 +1,84 @@
+"""
+Basic Pulp3Client initialization and context manager tests.
+Generated-by: Claude Code
+"""
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_client_initialization(pulp3_client):
+    """Test that client can be initialized with basic parameters."""
+    client = pulp3_client(auth=("user", "pass"), timeout=30.0)
+    assert client._url == "https://pulp.example.com/api/pulp/test-domain/api/v3/"
+    assert client._domain == "test-domain"
+    assert client._api_path == "/api/pulp/test-domain/api/v3/"
+    assert client._timeout == 30.0
+
+
+@pytest.mark.anyio
+async def test_client_initialization_custom_domain(pulp3_client):
+    """Test that client can be initialized with a custom domain."""
+    client = pulp3_client(domain="custom-domain")
+    assert client._url == "https://pulp.example.com/api/pulp/custom-domain/api/v3/"
+    assert client._domain == "custom-domain"
+    assert client._api_path == "/api/pulp/custom-domain/api/v3/"
+
+
+@pytest.mark.anyio
+async def test_client_initialization_default_domain():
+    """Test that client uses 'default' domain when not specified."""
+    from pubtools.pulplib._impl.client_pulp3.client import Pulp3Client
+
+    client = Pulp3Client(url="https://pulp.example.com")
+    assert client._domain == "default"
+    assert client._api_path == "/api/pulp/default/api/v3/"
+
+
+@pytest.mark.anyio
+async def test_client_initialization_with_retry_params(pulp3_client):
+    """Test client initialization with custom retry parameters."""
+    client = pulp3_client(max_retries=3, retry_min_wait=0.5, retry_max_wait=30.0)
+    assert client._retry_policy is not None
+
+
+@pytest.mark.anyio
+async def test_client_context_manager(pulp3_client):
+    """Test client can be used as async context manager."""
+    async with pulp3_client() as client:
+        assert client._client is not None
+        assert client._limiter is not None
+
+    # After exit, client should be closed
+    assert client._client is None
+    assert client._limiter is None
+
+
+@pytest.mark.anyio
+async def test_request_without_context_raises(pulp3_client):
+    """Test that making requests outside context manager raises error."""
+    client = pulp3_client()
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await client.get_status()
+
+
+@pytest.mark.anyio
+async def test_client_with_auth(pulp3_client):
+    """Test client initialization with authentication."""
+    client = pulp3_client(auth=("username", "password"))
+    assert client._auth is not None
+
+
+@pytest.mark.anyio
+async def test_client_with_cert(pulp3_client):
+    """Test client initialization with certificate."""
+    client = pulp3_client(cert="/path/to/cert.pem")
+    assert client._cert == "/path/to/cert.pem"
+
+
+@pytest.mark.anyio
+async def test_client_verify_ssl(pulp3_client):
+    """Test client initialization with SSL verification settings."""
+    client = pulp3_client(verify=False)
+    assert client._verify is False

--- a/tests/client_pulp3/test_client_content.py
+++ b/tests/client_pulp3/test_client_content.py
@@ -1,0 +1,97 @@
+"""
+Test Pulp3Client content operations.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_modify_repo_content_with_id(respx_mock, pulp3_client):
+    """Test modifying repository content using repository ID."""
+    repo_id = "123"
+
+    respx_mock.post(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/{repo_id}/modify/"
+    ).mock(return_value=httpx.Response(202, json={"task": "/pulp/api/v3/tasks/789/"}))
+
+    async with pulp3_client() as client:
+        task_href = await client.modify_repo_content(
+            repository_href_or_id=repo_id,
+            add_content_units=["content-1", "content-2"],
+            remove_content_units=["content-3"],
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/789/"
+
+
+@pytest.mark.anyio
+async def test_modify_repo_content_with_href(respx_mock, pulp3_client):
+    """Test modifying repository content using repository href."""
+    repo_id = "456"
+    repo_href = f"/api/pulp/test-domain/api/v3/repositories/rpm/rpm/{repo_id}/"
+
+    respx_mock.post(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/{repo_id}/modify/"
+    ).mock(return_value=httpx.Response(202, json={"task": "/pulp/api/v3/tasks/999/"}))
+
+    async with pulp3_client() as client:
+        task_href = await client.modify_repo_content(
+            repository_href_or_id=repo_href,
+            add_content_units=["content-1"],
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/999/"
+
+
+@pytest.mark.anyio
+async def test_modify_repo_content_add_only(respx_mock, pulp3_client):
+    """Test adding content to repository."""
+    repo_id = "456"
+
+    respx_mock.post(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/{repo_id}/modify/"
+    ).mock(return_value=httpx.Response(202, json={"task": "/pulp/api/v3/tasks/111/"}))
+
+    async with pulp3_client() as client:
+        task_href = await client.modify_repo_content(
+            repository_href_or_id=repo_id,
+            add_content_units=["content-1", "content-2"],
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/111/"
+
+
+@pytest.mark.anyio
+async def test_modify_repo_content_remove_only(respx_mock, pulp3_client):
+    """Test removing content from repository."""
+    repo_id = "789"
+
+    respx_mock.post(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/{repo_id}/modify/"
+    ).mock(return_value=httpx.Response(202, json={"task": "/pulp/api/v3/tasks/222/"}))
+
+    async with pulp3_client() as client:
+        task_href = await client.modify_repo_content(
+            repository_href_or_id=repo_id,
+            remove_content_units=["content-1"],
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/222/"
+
+
+@pytest.mark.anyio
+async def test_modify_repo_content_no_changes_raises(pulp3_client):
+    """Test that modifying with no content raises ValueError."""
+    async with pulp3_client() as client:
+        with pytest.raises(ValueError, match="No content to modify"):
+            await client.modify_repo_content(
+                repository_href_or_id="123",
+                add_content_units=None,
+                remove_content_units=None,
+            )

--- a/tests/client_pulp3/test_client_distributions.py
+++ b/tests/client_pulp3/test_client_distributions.py
@@ -1,0 +1,62 @@
+"""
+Test Pulp3Client distribution operations.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_create_distribution(respx_mock, pulp3_client):
+    """Test creating a distribution."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/distributions/rpm/rpm/"
+    ).mock(
+        return_value=httpx.Response(
+            202,
+            json={
+                "task": "/pulp/api/v3/tasks/123/",
+                "name": "test-dist",
+                "base_path": "test/path",
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        task_href = await client.create_distribution(
+            repository_href="/pulp/api/v3/repositories/rpm/rpm/456/",
+            base_path="test/path",
+            name="test-dist",
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/123/"
+
+
+@pytest.mark.anyio
+async def test_create_distribution_with_repository_href(respx_mock, pulp3_client):
+    """Test creating a distribution with repository href."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/distributions/rpm/rpm/"
+    ).mock(
+        return_value=httpx.Response(
+            202,
+            json={
+                "task": "/pulp/api/v3/tasks/789/",
+                "name": "prod-dist",
+                "base_path": "production/repo",
+                "repository": "/pulp/api/v3/repositories/rpm/rpm/999/",
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        task_href = await client.create_distribution(
+            repository_href="/pulp/api/v3/repositories/rpm/rpm/999/",
+            base_path="production/repo",
+            name="prod-dist",
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/789/"

--- a/tests/client_pulp3/test_client_errors.py
+++ b/tests/client_pulp3/test_client_errors.py
@@ -93,20 +93,6 @@ async def test_404_after_retries(respx_mock, pulp3_client):
 
 
 @pytest.mark.anyio
-async def test_http_400_error_raises(respx_mock, pulp3_client):
-    """Test that 400 Bad Request raises HTTPStatusError."""
-    respx_mock.post(
-        "https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/"
-    ).mock(return_value=httpx.Response(400, json={"detail": "Invalid data"}))
-
-    async with pulp3_client() as client:
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
-            await client.create_repository(name="bad-name")
-
-        assert exc_info.value.response.status_code == 400
-
-
-@pytest.mark.anyio
 async def test_http_401_unauthorized_raises(respx_mock, pulp3_client):
     """Test that 401 Unauthorized raises HTTPStatusError."""
     respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(

--- a/tests/client_pulp3/test_client_errors.py
+++ b/tests/client_pulp3/test_client_errors.py
@@ -1,0 +1,120 @@
+"""
+Test Pulp3Client error handling.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_404_not_found(respx_mock, pulp3_client):
+    """Test that 404 errors are handled gracefully."""
+    respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/nonexistent/"
+    ).mock(return_value=httpx.Response(404, json={"detail": "Not found"}))
+
+    async with pulp3_client() as client:
+        # Based on current implementation, 404 returns None
+        result = await client._request("GET", "/nonexistent/")
+        assert result is None
+
+
+@pytest.mark.anyio
+async def test_http_500_error_raises(respx_mock, pulp3_client):
+    """Test that 500 errors raise HTTPStatusError."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(500, json={"detail": "Internal server error"})
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_status()
+
+
+@pytest.mark.anyio
+async def test_http_503_service_unavailable(respx_mock, pulp3_client):
+    """Test that 503 errors raise HTTPStatusError."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(503, json={"detail": "Service unavailable"})
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_status()
+
+
+@pytest.mark.anyio
+async def test_json_decode_error_raises(respx_mock, pulp3_client):
+    """Test that JSON decode errors raise JSONDecodeError."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(200, text="not json")
+    )
+
+    async with pulp3_client() as client:
+        from json import JSONDecodeError
+
+        with pytest.raises(JSONDecodeError):
+            await client.get_status()
+
+
+@pytest.mark.anyio
+async def test_connection_error(respx_mock, pulp3_client):
+    """Test that connection errors are raised."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        side_effect=httpx.ConnectError("Connection failed")
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(httpx.ConnectError):
+            await client.get_status()
+
+
+@pytest.mark.anyio
+async def test_404_after_retries(respx_mock, pulp3_client):
+    """Test that 404 is handled correctly even with retries."""
+    route = respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/nonexistent/"
+    )
+
+    # First attempt fails with 500, second returns 404
+    route.mock(
+        side_effect=[
+            httpx.Response(500, json={"detail": "Server error"}),
+            httpx.Response(404, json={"detail": "Not found"}),
+        ]
+    )
+
+    async with pulp3_client(max_retries=2) as client:
+        result = await client._request("GET", "/nonexistent/")
+        assert result is None
+        # Should have tried twice (500 triggers retry, then 404)
+        assert route.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_http_400_error_raises(respx_mock, pulp3_client):
+    """Test that 400 Bad Request raises HTTPStatusError."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/"
+    ).mock(return_value=httpx.Response(400, json={"detail": "Invalid data"}))
+
+    async with pulp3_client() as client:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.create_repository(name="bad-name")
+
+        assert exc_info.value.response.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_http_401_unauthorized_raises(respx_mock, pulp3_client):
+    """Test that 401 Unauthorized raises HTTPStatusError."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(401, json={"detail": "Unauthorized"})
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_status()
+
+        assert exc_info.value.response.status_code == 401

--- a/tests/client_pulp3/test_client_repositories.py
+++ b/tests/client_pulp3/test_client_repositories.py
@@ -1,0 +1,82 @@
+"""
+Test Pulp3Client repository operations.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_create_repository_success(respx_mock, pulp3_client):
+    """Test successful repository creation."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/"
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "pulp_href": "/pulp/api/v3/repositories/rpm/rpm/123/",
+                "name": "test-repo",
+                "description": "Test repository",
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        repo = await client.create_repository(
+            name="test-repo", description="Test repository"
+        )
+
+        assert repo["name"] == "test-repo"
+        assert repo["description"] == "Test repository"
+        assert repo["pulp_href"] == "/pulp/api/v3/repositories/rpm/rpm/123/"
+
+
+@pytest.mark.anyio
+async def test_create_repository_with_kwargs(respx_mock, pulp3_client):
+    """Test repository creation with additional kwargs."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/repositories/rpm/rpm/"
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "pulp_href": "/pulp/api/v3/repositories/rpm/rpm/456/",
+                "name": "test-repo-2",
+                "retain_repo_versions": 3,
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        repo = await client.create_repository(
+            name="test-repo-2", retain_repo_versions=3
+        )
+
+        assert repo["name"] == "test-repo-2"
+        assert repo["retain_repo_versions"] == 3
+
+
+@pytest.mark.anyio
+async def test_create_publication(respx_mock, pulp3_client):
+    """Test creating a publication for a repository."""
+    respx_mock.post(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/publications/rpm/rpm/"
+    ).mock(
+        return_value=httpx.Response(
+            202,
+            json={
+                "task": "/pulp/api/v3/tasks/789/",
+                "repository": "/pulp/api/v3/repositories/rpm/rpm/123/",
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        task_href = await client.create_publication(
+            repository_href="/pulp/api/v3/repositories/rpm/rpm/123/"
+        )
+
+        assert isinstance(task_href, str)
+        assert task_href == "/pulp/api/v3/tasks/789/"

--- a/tests/client_pulp3/test_client_requests.py
+++ b/tests/client_pulp3/test_client_requests.py
@@ -1,0 +1,187 @@
+"""
+Test Pulp3Client HTTP request methods.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_get_status_success(respx_mock, pulp3_client):
+    """Test successful status request."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "versions": [{"component": "core", "version": "3.21.0"}],
+                "online_workers": [],
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        status = await client.get_status()
+
+        assert "versions" in status
+        assert status["versions"][0]["component"] == "core"
+
+
+@pytest.mark.anyio
+async def test_request_with_204_no_content(respx_mock, pulp3_client):
+    """Test that 204 No Content returns empty dict."""
+    respx_mock.delete(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/distributions/rpm/rpm/123/"
+    ).mock(return_value=httpx.Response(204))
+
+    async with pulp3_client() as client:
+        result = await client._request("DELETE", "/distributions/rpm/rpm/123/")
+        assert result is None
+
+
+@pytest.mark.anyio
+async def test_search_content(respx_mock, pulp3_client):
+    """Test content search."""
+    query = "(sha256=abc123)"
+
+    respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/content/rpm/packages/"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "results": [
+                    {
+                        "pulp_href": "/pulp/api/v3/content/rpm/packages/1/",
+                        "name": "test-package",
+                        "sha256": "abc123",
+                    }
+                ],
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        results = await client.search_content(query)
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert results[0]["name"] == "test-package"
+        assert results[0]["sha256"] == "abc123"
+
+
+@pytest.mark.anyio
+async def test_search_content_with_fields(respx_mock, pulp3_client):
+    """Test content search with specific fields."""
+    query = "(sha256=def456)"
+
+    respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/content/rpm/packages/"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "results": [
+                    {
+                        "pulp_href": "/pulp/api/v3/content/rpm/packages/2/",
+                        "name": "another-package",
+                    }
+                ],
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        results = await client.search_content(query, fields=["name", "pulp_href"])
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert results[0]["name"] == "another-package"
+
+
+@pytest.mark.anyio
+async def test_search_content_empty_results(respx_mock, pulp3_client):
+    """Test content search with no results."""
+    query = "(sha256=nonexistent)"
+
+    respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/content/rpm/packages/"
+    ).mock(return_value=httpx.Response(200, json={"count": 0, "results": []}))
+
+    async with pulp3_client() as client:
+        results = await client.search_content(query)
+
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+
+@pytest.mark.anyio
+async def test_search_content_handles_none_response(respx_mock, pulp3_client):
+    """Test search_content when response is None (404)."""
+    query = "(sha256=test)"
+
+    respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/content/rpm/packages/"
+    ).mock(return_value=httpx.Response(404, json={"detail": "Not found"}))
+
+    async with pulp3_client() as client:
+        results = await client.search_content(query)
+
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+
+@pytest.mark.anyio
+async def test_build_query_sha256(pulp3_client):
+    """Test building search query by SHA256 checksums."""
+    async with pulp3_client() as client:
+        checksums = ["abc123", "def456", "ghi789"]
+        query = client.build_query_sha256(checksums)
+
+        assert isinstance(query, str)
+        assert "sha256=abc123" in query
+        assert "sha256=def456" in query
+        assert "sha256=ghi789" in query
+        assert " OR " in query
+        assert query.startswith("(")
+        assert query.endswith(")")
+
+
+@pytest.mark.anyio
+async def test_build_query_sha256_single_checksum(pulp3_client):
+    """Test building query with single checksum."""
+    async with pulp3_client() as client:
+        query = client.build_query_sha256(["single123"])
+
+        assert isinstance(query, str)
+        assert query == "(sha256=single123)"
+
+
+@pytest.mark.anyio
+async def test_successful_request_returns_dict(respx_mock, pulp3_client):
+    """Test that successful requests return proper dict type."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(200, json={"status": "ok"})
+    )
+
+    async with pulp3_client() as client:
+        result = await client.get_status()
+
+        assert isinstance(result, dict)
+        assert result["status"] == "ok"
+
+
+@pytest.mark.anyio
+async def test_empty_json_response(respx_mock, pulp3_client):
+    """Test that empty JSON object is handled correctly."""
+    respx_mock.get("https://pulp.example.com/api/pulp/test-domain/api/v3/status/").mock(
+        return_value=httpx.Response(200, json={})
+    )
+
+    async with pulp3_client() as client:
+        result = await client.get_status()
+
+        assert result == {}
+        assert isinstance(result, dict)

--- a/tests/client_pulp3/test_client_retry.py
+++ b/tests/client_pulp3/test_client_retry.py
@@ -1,0 +1,84 @@
+"""
+Test Pulp3Client retry behavior.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+
+@pytest.mark.anyio
+async def test_retry_on_failure_then_success(respx_mock, pulp3_client):
+    """Test that requests are retried on failure."""
+    route = respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/status/"
+    )
+
+    # First two attempts fail, third succeeds
+    route.mock(
+        side_effect=[
+            httpx.Response(500, json={"detail": "Server error"}),
+            httpx.Response(503, json={"detail": "Service unavailable"}),
+            httpx.Response(200, json={"status": "ok"}),
+        ]
+    )
+
+    async with pulp3_client(max_retries=3) as client:
+        result = await client.get_status()
+        assert result == {"status": "ok"}
+        assert route.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_retry_exhausted_raises(respx_mock, pulp3_client):
+    """Test that exhausted retries raise exception."""
+    route = respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/status/"
+    )
+
+    # All attempts fail
+    route.mock(return_value=httpx.Response(500, json={"detail": "Server error"}))
+
+    async with pulp3_client(max_retries=2) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_status()
+
+        # Should have tried max_retries times
+        assert route.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_retry_with_connection_error(respx_mock, pulp3_client):
+    """Test retry behavior with connection errors."""
+    route = respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/status/"
+    )
+
+    # First attempt fails with connection error, second succeeds
+    route.mock(
+        side_effect=[
+            httpx.ConnectError("Connection failed"),
+            httpx.Response(200, json={"status": "ok"}),
+        ]
+    )
+
+    async with pulp3_client(max_retries=3) as client:
+        result = await client.get_status()
+        assert result == {"status": "ok"}
+        assert route.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_no_retry_on_success(respx_mock, pulp3_client):
+    """Test that successful requests are not retried."""
+    route = respx_mock.get(
+        "https://pulp.example.com/api/pulp/test-domain/api/v3/status/"
+    )
+
+    route.mock(return_value=httpx.Response(200, json={"status": "ok"}))
+
+    async with pulp3_client(max_retries=5) as client:
+        result = await client.get_status()
+        assert result == {"status": "ok"}
+        # Should only call once on success
+        assert route.call_count == 1

--- a/tests/client_pulp3/test_client_tasks.py
+++ b/tests/client_pulp3/test_client_tasks.py
@@ -1,0 +1,154 @@
+"""
+Test Pulp3Client task polling functionality.
+Generated-by: Claude Code
+"""
+
+import pytest
+import httpx
+
+from pubtools.pulplib._impl.client_pulp3.errors import Pulp3TaskException
+
+
+@pytest.mark.anyio
+async def test_poll_task_success(respx_mock, pulp3_client):
+    """Test successful task polling with task ID."""
+    task_id = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+
+    route = respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_id}/"
+    )
+
+    # First two polls show running, third shows completed
+    route.mock(
+        side_effect=[
+            httpx.Response(
+                200, json={"state": "running", "pulp_href": f"/tasks/{task_id}/"}
+            ),
+            httpx.Response(
+                200, json={"state": "running", "pulp_href": f"/tasks/{task_id}/"}
+            ),
+            httpx.Response(
+                200, json={"state": "completed", "pulp_href": f"/tasks/{task_id}/"}
+            ),
+        ]
+    )
+
+    async with pulp3_client() as client:
+        result = await client.poll_task(task_id, poll_interval=0.01, timeout=5.0)
+
+        assert isinstance(result, dict)
+        assert result["state"] == "completed"
+        assert route.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_poll_task_with_href(respx_mock, pulp3_client):
+    """Test task polling with task href (extracts ID from href)."""
+    task_id = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+    task_href = f"/api/pulp/test-domain/api/v3/tasks/{task_id}/"
+
+    route = respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_id}/"
+    )
+
+    route.mock(
+        return_value=httpx.Response(
+            200, json={"state": "completed", "pulp_href": task_href}
+        )
+    )
+
+    async with pulp3_client() as client:
+        # Pass full href, client should extract ID
+        result = await client.poll_task(task_href, poll_interval=0.01, timeout=5.0)
+
+        assert isinstance(result, dict)
+        assert result["state"] == "completed"
+        assert route.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_poll_task_immediate_completion(respx_mock, pulp3_client):
+    """Test task polling when task is already completed."""
+    task_id = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+
+    route = respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_id}/"
+    )
+
+    route.mock(
+        return_value=httpx.Response(
+            200, json={"state": "completed", "pulp_href": f"/tasks/{task_id}/"}
+        )
+    )
+
+    async with pulp3_client() as client:
+        result = await client.poll_task(task_id, poll_interval=0.01, timeout=5.0)
+
+        assert isinstance(result, dict)
+        assert result["state"] == "completed"
+        assert route.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_poll_task_failure(respx_mock, pulp3_client):
+    """Test task polling when task fails."""
+    task_href = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+
+    respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_href}/"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "state": "failed",
+                "pulp_href": f"/tasks/{task_href}/",
+                "error": {"description": "Task failed due to error"},
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(Pulp3TaskException, match="Task .* failed"):
+            await client.poll_task(task_href, poll_interval=0.01, timeout=5.0)
+
+
+@pytest.mark.anyio
+async def test_poll_task_canceled(respx_mock, pulp3_client):
+    """Test task polling when task is canceled."""
+    task_href = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+
+    respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_href}/"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "state": "canceled",
+                "pulp_href": f"/tasks/{task_href}/",
+                "error": {"description": "Task was canceled"},
+            },
+        )
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(Pulp3TaskException, match="Task .* canceled"):
+            await client.poll_task(task_href, poll_interval=0.01, timeout=5.0)
+
+
+@pytest.mark.anyio
+async def test_poll_task_timeout(respx_mock, pulp3_client):
+    """Test task polling timeout."""
+    task_href = "018d5c8e-6f42-7c6e-8e3b-7f8e3a8f7e3a"
+
+    # Task never completes, always returns running
+    respx_mock.get(
+        f"https://pulp.example.com/api/pulp/test-domain/api/v3/tasks/{task_href}/"
+    ).mock(
+        return_value=httpx.Response(
+            200, json={"state": "running", "pulp_href": f"/tasks/{task_href}/"}
+        )
+    )
+
+    async with pulp3_client() as client:
+        with pytest.raises(TimeoutError):
+            await client.poll_task(task_href, poll_interval=0.01, timeout=0.1)


### PR DESCRIPTION
Added 'raw' client for pulp3 API for basic operations required for:
* repository creation, content search (limited), creation of publication
  and distribution and some other functions like polling tasks.
* written as async using anyio with trio backend, using httpx requests and
  tenacity for retries
* it is expected that this code will undergo further optimization and
  refactoring with higher level of abstraction