### PR TITLE
Onboard test coverage to Codecov [RHELDST-40406]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -37,6 +37,8 @@ jobs:
         run: tox -e pidiff
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Install OS packages
@@ -51,6 +53,14 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref =='refs/heads/master')
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds the codecov action to the coverage workflow in tox-test.yml